### PR TITLE
Added some guards to keep execution in a node context from throwing ReferenceErrors

### DIFF
--- a/dist/filepond.esm.js
+++ b/dist/filepond.esm.js
@@ -7087,10 +7087,14 @@ const state = {
 const name = 'filepond';
 
 // is in browser
-const hasNavigator = typeof navigator !== 'undefined';
+const hasNavigator =
+  typeof navigator !== 'undefined' &&
+  typeof window !== 'undefined' &&
+  typeof document !== 'undefined';
 
 // app painter, cannot be paused or stopped at the moment
 const painter =
+  hasTiming &&
   hasNavigator &&
   createPainter(createUpdater(state.apps, '_read', '_write'), 60);
 

--- a/dist/filepond.esm.js
+++ b/dist/filepond.esm.js
@@ -7094,8 +7094,8 @@ const hasNavigator =
 
 // app painter, cannot be paused or stopped at the moment
 const painter =
-  hasTiming &&
   hasNavigator &&
+  hasTiming() &&
   createPainter(createUpdater(state.apps, '_read', '_write'), 60);
 
 // fire load event

--- a/dist/filepond.esm.js
+++ b/dist/filepond.esm.js
@@ -7092,10 +7092,13 @@ const hasNavigator =
   typeof window !== 'undefined' &&
   typeof document !== 'undefined';
 
+const hasPerformance =
+  typeof performance !== 'undefined';
+
 // app painter, cannot be paused or stopped at the moment
 const painter =
   hasNavigator &&
-  hasTiming() &&
+  hasPerformance &&
   createPainter(createUpdater(state.apps, '_read', '_write'), 60);
 
 // fire load event

--- a/dist/filepond.js
+++ b/dist/filepond.js
@@ -8220,10 +8220,14 @@ function signature:
     typeof window !== 'undefined' &&
     typeof document !== 'undefined';
 
+  // performance global is available
+  var hasPerformance = 
+    typeof performance !== 'undefined';
+
   // app painter, cannot be paused or stopped at the moment
   var painter =
     hasNavigator &&
-    hasTiming() &&
+    hasPerformance &&
     createPainter(createUpdater(state.apps, '_read', '_write'), 60);
 
   // fire load event

--- a/dist/filepond.js
+++ b/dist/filepond.js
@@ -8215,10 +8215,14 @@ function signature:
   var name = 'filepond';
 
   // is in browser
-  var hasNavigator = typeof navigator !== 'undefined';
+  var hasNavigator =
+    typeof navigator !== 'undefined' &&
+    typeof window !== 'undefined' &&
+    typeof document !== 'undefined';
 
   // app painter, cannot be paused or stopped at the moment
   var painter =
+    hasTiming &&
     hasNavigator &&
     createPainter(createUpdater(state.apps, '_read', '_write'), 60);
 

--- a/dist/filepond.js
+++ b/dist/filepond.js
@@ -8222,8 +8222,8 @@ function signature:
 
   // app painter, cannot be paused or stopped at the moment
   var painter =
-    hasTiming &&
     hasNavigator &&
+    hasTiming() &&
     createPainter(createUpdater(state.apps, '_read', '_write'), 60);
 
   // fire load event


### PR DESCRIPTION
My team is using react-filepond in a React UI kit, and we love it! There's one issue we ran into with server-side-rendered applications that imported our implementing component: we'd get ReferenceErrors for performance, window and document. These guards here make it so our component renders fine on the server and works in the browser.