### PR TITLE
Add typescript definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "filepond",
-    "version": "4.4.12",
+    "version": "4.5.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1238,6 +1238,12 @@
             "integrity": "sha512-pz6wNe/XwyesgfVX7P6B0hY3TnTAYXk6KSTLdpQfbuq3be+hnMoCuFzE+yLTskPdBwmNiGRL2TAsnF09aRugvQ==",
             "dev": true
         },
+        "@types/parsimmon": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.0.tgz",
+            "integrity": "sha512-bsTIJFVQv7jnvNiC42ld2pQW2KRI+pAG243L+iATvqzy3X6+NH1obz2itRKDZZ8VVhN3wjwYax/VBGCcXzgTqQ==",
+            "dev": true
+        },
         "@types/q": {
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
@@ -1587,6 +1593,65 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
             "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
             "dev": true
+        },
+        "babel-code-frame": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
         },
         "babel-jest": {
             "version": "24.8.0",
@@ -2547,6 +2612,16 @@
                 }
             }
         },
+        "definitelytyped-header-parser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-1.2.0.tgz",
+            "integrity": "sha512-xpg8uu/2YD/reaVsZV4oJ4g7UDYFqQGWvT1W9Tsj6q4VtWBSaig38Qgah0ZMnQGF9kAsAim08EXDO1nSi0+Nog==",
+            "dev": true,
+            "requires": {
+                "@types/parsimmon": "^1.3.0",
+                "parsimmon": "^1.2.0"
+            }
+        },
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2634,6 +2709,60 @@
             "dev": true,
             "requires": {
                 "is-obj": "^1.0.0"
+            }
+        },
+        "download-file-sync": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/download-file-sync/-/download-file-sync-1.0.4.tgz",
+            "integrity": "sha1-0+PFQ/g29BA5RVuQNMcuNVsDYBk=",
+            "dev": true
+        },
+        "dts-critic": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dts-critic/-/dts-critic-2.0.0.tgz",
+            "integrity": "sha512-oYo69B8NcjUoDhKh8oUl58ljMsgyWnPR0Qf3QKJmKjm5LvkQ21v4SW+QCOleI1Cs0HRN6zEYllvQEORGd45wOQ==",
+            "dev": true,
+            "requires": {
+                "definitelytyped-header-parser": "^1.2.0",
+                "download-file-sync": "^1.0.4",
+                "semver": "^6.2.0",
+                "yargs": "^12.0.5"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "dtslint": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-0.9.2.tgz",
+            "integrity": "sha512-X/baOkTLSpWclVn+q2XR2d9FLGVJNBtvU093Pha+tmX1EHjLhy8CgDkM7DLtKTyZLQzROsxmKK7BBgGLJQ7ooQ==",
+            "dev": true,
+            "requires": {
+                "definitelytyped-header-parser": "1.2.0",
+                "dts-critic": "^2.0.0",
+                "fs-extra": "^6.0.1",
+                "request": "^2.88.0",
+                "strip-json-comments": "^2.0.1",
+                "tslint": "5.14.0",
+                "typescript": "^3.5.3"
+            },
+            "dependencies": {
+                "fs-extra": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+                    "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                }
             }
         },
         "ecc-jsbn": {
@@ -3090,7 +3219,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -3111,12 +3241,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -3131,17 +3263,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -3258,7 +3393,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -3270,6 +3406,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -3284,6 +3421,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -3291,12 +3429,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -3315,6 +3455,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3395,7 +3536,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -3407,6 +3549,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3492,7 +3635,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -3528,6 +3672,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3547,6 +3692,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3590,12 +3736,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -6059,6 +6207,12 @@
             "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
             "dev": true
         },
+        "parsimmon": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.13.0.tgz",
+            "integrity": "sha512-5UIrOCW+gjbILkjKPgTgmq8LKf8TT3Iy7kN2VD7OtQ81facKn8B4gG1X94jWqXYZsxG2KbJhrv/Yq/5H6BQn7A==",
+            "dev": true
+        },
         "pascalcase": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -7904,6 +8058,12 @@
                 "get-stdin": "^4.0.1"
             }
         },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
         "stylehacks": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
@@ -8113,6 +8273,56 @@
                 "glob": "^7.1.2"
             }
         },
+        "tslib": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+            "dev": true
+        },
+        "tslint": {
+            "version": "5.14.0",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
+            "integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.7.0",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.29.0"
+            },
+            "dependencies": {
+                "builtin-modules": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                    "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+                    "dev": true
+                },
+                "diff": {
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+                    "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+                    "dev": true
+                }
+            }
+        },
+        "tsutils": {
+            "version": "2.29.0",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+            "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.8.1"
+            }
+        },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -8136,6 +8346,12 @@
             "requires": {
                 "prelude-ls": "~1.1.2"
             }
+        },
+        "typescript": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+            "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+            "dev": true
         },
         "uglify-js": {
             "version": "3.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "filepond",
-    "version": "4.5.0",
+    "version": "4.5.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -2738,9 +2738,9 @@
             }
         },
         "dtslint": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-0.9.2.tgz",
-            "integrity": "sha512-X/baOkTLSpWclVn+q2XR2d9FLGVJNBtvU093Pha+tmX1EHjLhy8CgDkM7DLtKTyZLQzROsxmKK7BBgGLJQ7ooQ==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-0.9.3.tgz",
+            "integrity": "sha512-nk71dlxXhvx4U7zIBQt+7UoJKotKT/dv8pQljFevl2RZvpbwmQ5czw/MArf+DjLQEt6QgeUXUa/RNpLcv8s+yA==",
             "dev": true,
             "requires": {
                 "definitelytyped-header-parser": "1.2.0",
@@ -2749,7 +2749,7 @@
                 "request": "^2.88.0",
                 "strip-json-comments": "^2.0.1",
                 "tslint": "5.14.0",
-                "typescript": "^3.5.3"
+                "typescript": "^3.7.0-dev.20190829"
             },
             "dependencies": {
                 "fs-extra": {
@@ -2762,6 +2762,12 @@
                         "jsonfile": "^4.0.0",
                         "universalify": "^0.1.0"
                     }
+                },
+                "typescript": {
+                    "version": "3.7.0-dev.20190829",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.0-dev.20190829.tgz",
+                    "integrity": "sha512-qyRMr1LuxkE8Su38W6t7YtRI8wotu4TiAUpnD8QIxYBHiyalNTC2GsGJGGrYXSZ5d1RM0VG4PNrHOxA0byfhKg==",
+                    "dev": true
                 }
             }
         },
@@ -8348,9 +8354,9 @@
             }
         },
         "typescript": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-            "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
+            "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
             "dev": true
         },
         "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "files": [
         "dist"
     ],
+    "types": "types",
     "scripts": {
         "test": "npx jest",
         "start": "npx rollup -c -w",
@@ -39,7 +40,8 @@
         "scripts": "npx rollup -c",
         "styles": "npm run styles:pretty && npm run styles:nano",
         "styles:pretty": "cat src/css/* | npx node-sass | npx postcss --no-map --use autoprefixer | npx prettier --single-quote --parser css | node banner-cli.js FilePond > dist/filepond.css",
-        "styles:nano": "cat src/css/* | npx node-sass | npx postcss --no-map --use autoprefixer --use cssnano | node banner-cli.js FilePond > dist/filepond.min.css"
+        "styles:nano": "cat src/css/* | npx node-sass | npx postcss --no-map --use autoprefixer --use cssnano | node banner-cli.js FilePond > dist/filepond.min.css",
+        "dtslint": "dtslint types"
     },
     "devDependencies": {
         "@babel/core": "^7.5.5",
@@ -49,6 +51,7 @@
         "autoprefixer": "^9.6.1",
         "babel-jest": "^24.8.0",
         "cssnano": "^4.1.10",
+        "dtslint": "^0.9.2",
         "jest": "^24.8.0",
         "node-sass": "^4.12.0",
         "postcss-cli": "^6.1.3",
@@ -59,6 +62,7 @@
         "rollup-plugin-license": "^0.8.1",
         "rollup-plugin-node-resolve": "^4.2.4",
         "rollup-plugin-prettier": "^0.6.0",
-        "rollup-plugin-terser": "^4.0.4"
+        "rollup-plugin-terser": "^4.0.4",
+        "typescript": "^3.5.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "autoprefixer": "^9.6.1",
         "babel-jest": "^24.8.0",
         "cssnano": "^4.1.10",
-        "dtslint": "^0.9.2",
+        "dtslint": "^0.9.3",
         "jest": "^24.8.0",
         "node-sass": "^4.12.0",
         "postcss-cli": "^6.1.3",
@@ -64,6 +64,6 @@
         "rollup-plugin-node-resolve": "^4.2.4",
         "rollup-plugin-prettier": "^0.6.0",
         "rollup-plugin-terser": "^4.0.4",
-        "typescript": "^3.5.3"
+        "typescript": "^3.6.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
         "Android >= 4.4"
     ],
     "files": [
-        "dist"
+        "dist",
+        "types/*.d.ts"
     ],
-    "types": "types",
+    "types": "types/index.d.ts",
     "scripts": {
         "test": "npx jest",
         "start": "npx rollup -c -w",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -272,9 +272,13 @@ interface FilePondLabelProps {
 }
 
 interface FilePondSvgIconProps {
+    /** The icon used for remove actions */
     iconRemove?: string;
+    /** The icon used for process actions */
     iconProcess?: string;
+    /** The icon used for retry actions */
     iconRetry?: string;
+     /** The icon used for undo actions */
     iconUndo?: string;
 }
 
@@ -419,20 +423,35 @@ export class FilePond {
     getFile: () => File;
     getFiles: () => File[];
     browse: () => void;
-    context: () => void;
+    sort: (compare: () => void) => void;
+    destroy: () => void;
+
+    /** Inserts the FilePond instance after the supplied element */
+    insertAfter: (element: Element) => void;
+    /** Inserts the FilePond instance before the supplied element */
+    insertBefore: (element: Element) => void;
+    /** Appends FilePond to the given element  */
+    appendTo: (element: Element) => void;
+    /** Returns true if the current instance is attached to the supplied element */
+    isAttachedTo: (element: Element) => void;
+    /** Replaces the supplied element with FilePond */
+    replaceElement: (element: Element) => void;
+    /** If FilePond replaced the original element, this restores the original element to its original glory */
+    restoreElement: (element: Element) => void;
+
 }
 
 /** Creates a new FilePond instance */
-export function create(element?: any, options?: FilePondProps): FilePond;
+export function create(element?: Element, options?: FilePondProps): FilePond;
 /** Destroys the FilePond instance attached to the supplied element */
-export function destroy(element: any): void;
+export function destroy(element: Element): void;
 /** Returns the FilePond instance attached to the supplied element */
-export function find(element: any): FilePond;
+export function find(element: Element): FilePond;
 /**
  * Parses a given section of the DOM tree for elements with class
  * .filepond and turns them into FilePond elements.
  */
-export function parse(context: any): void;
+export function parse(context: Element): void;
 /** Registers a FilePond plugin for later use */
 export function registerPlugin(...plugins: any[]): void;
 /** Sets page level default options for all FilePond instances */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -540,46 +540,106 @@ interface FilePondStyleProps {
 type CaptureAttribute = "camera" | "microphone" | "camcorder";
 
 interface FilePondBaseProps {
+    /** 
+     * The ID to add to the root element
+     * @default null
+     */
     id?: string;
-    name?: string;
-    disabled?: boolean;
-    /** Class Name to put on wrapper */
+    /**
+     * The input field name to use
+     * @default 'filepond'
+     */
+    name?: string;  
+    /** 
+     * Class Name to put on wrapper 
+     * @default null
+     */
     className?: string;
-    /** Sets the required attribute to the output field */
+    /** 
+     * Sets the required attribute to the output field
+     * @default false
+     */
     required?: boolean;
-    /** Sets the given value to the capture attribute */
+    /**
+     * Sets the disabled attribute to the output field
+     * @default false
+     */
+    disabled?: boolean;
+    /** 
+     * Sets the given value to the capture attribute
+     * @default null
+     */
     captureMethod?: CaptureAttribute;
 
-    /** Enable or disable drag n’ drop */
+    /** 
+     * Enable or disable drag n’ drop
+     * @default true
+     */
     allowDrop?: boolean;
-    /** Enable or disable file browser */
+    /** 
+     * Enable or disable file browser
+     * @default true
+     */
     allowBrowse?: boolean;
     /**
      * Enable or disable pasting of files. Pasting files is not
      * supported on all browsers.
+     * @default true
      */
     allowPaste?: boolean;
-    /** Enable or disable adding multiple files */
+    /** 
+     * Enable or disable adding multiple files
+     * @default false
+     */
     allowMultiple?: boolean;
-    /** Allow drop to replace a file, only works when allowMultiple is false */
+    /** 
+     * Allow drop to replace a file, only works when allowMultiple is false
+     * @default true
+     */
     allowReplace?: boolean;
-    /** Allows the user to undo file upload */
+    /** 
+     * Allows the user to revert file upload
+     * @default true
+     */
     allowRevert?: boolean;
-    /** Require the file to be reverted before removal */
+    /** 
+     * Require the file to be successfully reverted before continuing
+     * @default false
+     */
     forceRevert?: boolean;
 
-    /** The maximum number of files that filepond pond can handle */
+    /** 
+     * The maximum number of files that filepond pond can handle
+     * @default null
+     */
     maxFiles?: number;
-    /** Enables custom validity messages */
+    /** 
+     * Enables custom validity messages
+     * @default false
+     */
     checkValidity?: boolean;
 
+    /**
+     * Set to false to always add items to beginning or end of list
+     * @default true
+     */
     itemInsertLocationFreedom?: boolean;
+    /**
+     * Default index in list to add items that have been dropped at the top of the list
+     * @default 'before'
+     */
     itemInsertLocation?: 'before' | 'after' | ((a: File, b: File) => number);
+    /**
+     * The interval to use before showing each item being added to the list
+     * @default 75
+     */
     itemInsertInterval?: number;
 
-    /** The maximum number of files that can be uploaded in parallel */
+    /** 
+     * The maximum number of files that can be uploaded in parallel
+     * @default null
+     */
     maxParallelUploads?: number;
-    acceptedFileTypes?: string[];
 }
 
 export interface FilePondOptionProps extends
@@ -593,36 +653,146 @@ export interface FilePondOptionProps extends
     FilePondBaseProps {}
 
 export class FilePond {
+    /**
+     * The root element of the Filepond instance
+     */
     readonly element: Element | null;
+    /**
+     * Returns the current status of the FilePond instance
+     * @default Status.EMPTY
+     */
     readonly status: Status;
 
-    name: string;
+    /** 
+     * The ID to add to the root element
+     * @default null
+     */
+    id: string | null;
+    /**
+     * The input field name to use
+     * @default 'filepond'
+     */
+    name: string;  
+    /** 
+     * Class Name to put on wrapper 
+     * @default null
+     */
     className: string | null;
+    /** 
+     * Sets the required attribute to the output field
+     * @default false
+     */
     required: boolean;
+    /**
+     * Sets the disabled attribute to the output field
+     * @default false
+     */
     disabled: boolean;
+    /** 
+     * Sets the given value to the capture attribute
+     * @default null
+     */
     captureMethod: CaptureAttribute | null;
+
+    /** 
+     * Enable or disable drag n’ drop
+     * @default true
+     */
     allowDrop: boolean;
+    /** 
+     * Enable or disable file browser
+     * @default true
+     */
     allowBrowse: boolean;
+    /**
+     * Enable or disable pasting of files. Pasting files is not
+     * supported on all browsers.
+     * @default true
+     */
     allowPaste: boolean;
+    /** 
+     * Enable or disable adding multiple files
+     * @default false
+     */
     allowMultiple: boolean;
+    /** 
+     * Allow drop to replace a file, only works when allowMultiple is false
+     * @default true
+     */
     allowReplace: boolean;
+    /** 
+     * Allows the user to revert file upload
+     * @default true
+     */
     allowRevert: boolean;
+    /** 
+     * Require the file to be successfully reverted before continuing
+     * @default false
+     */
     forceRevert: boolean;
+
+    /** 
+     * The maximum number of files that filepond pond can handle
+     * @default null
+     */
     maxFiles: number | null;
-    maxParallelUploads: number | null;
+    /** 
+     * Enables custom validity messages
+     * @default false
+     */
     checkValidity: boolean;
 
+    /**
+     * Set to false to always add items to beginning or end of list
+     * @default true
+     */
     itemInsertLocationFreedom: boolean;
+    /**
+     * Default index in list to add items that have been dropped at the top of the list
+     * @default 'before'
+     */
     itemInsertLocation: 'before' | 'after' | ((a: File, b: File) => number);
+    /**
+     * The interval to use before showing each item being added to the list
+     * @default 75
+     */
     itemInsertInterval: number;
 
+    /** 
+     * The maximum number of files that can be uploaded in parallel
+     * @default null
+     */
+    maxParallelUploads: number | null;   
+
+    /** 
+     * FilePond will catch all files dropped on the webpage.
+     * @default false
+     */
     dropOnPage: boolean;
+    /** Require drop on the FilePond element itself to catch the file.
+     * @default true
+    */
     dropOnElement: boolean;
-    dropValidation: false;
+    /**
+     * When enabled, files are validated before they are dropped.
+     * A file is not added when it’s invalid.
+     * @default false
+     */
+    dropValidation: boolean;
+    /**
+     * Ignored file names when handling dropped directories.
+     * Dropping directories is not supported on all browsers.
+     * @default ['.ds_store', 'thumbs.db', 'desktop.ini']
+     */
     ignoredFiles: string[];
 
-    instantUpload: boolean;
-    server: string | {
+
+    /** 
+     * Server API Configuration.
+     * See: https://pqina.nl/filepond/docs/patterns/api/server
+     * @default null
+     */
+    server?: string | {
         url?: string
         timeout?: number
         process?: string | ServerUrl | ProcessServerConfigFunction;
@@ -630,75 +800,163 @@ export class FilePond {
         restore?: string | ServerUrl | RestoreServerConfigFunction;
         load?: string | ServerUrl | LoadServerConfigFunction;
         fetch?: string | ServerUrl | FetchServerConfigFunction;
-    } | null;   
-    files: FilePondInitialFile[] | ActualFileObject[] | Blob[] | string[];
+    } | null;
+    /** 
+     * Immediately upload new files to the server
+     * @default true
+     */
+    instantUpload?: boolean;
+    /**
+     * A list of file locations that should be loaded immediately.
+     * See: https://pqina.nl/filepond/docs/patterns/api/filepond-object/#setting-initial-files
+     * @default []
+     */
+    files?: FilePondInitialFile[] | ActualFileObject[] | Blob[] | string[];
 
     /**
      * The decimal separator used to render numbers.
      * By default this is determined automatically.
+     * @default 'auto'
      */
     labelDecimalSeparator: string;
     /**
      * The thousands separator used to render numbers.
      * By default this is determined automatically.
+     * @default 'auto'
      */
     labelThousandsSeparator: string;
     /**
      * Default label shown to indicate this is a drop area.
      * FilePond will automatically bind browse file events to
-     * the element with CSS class .filepond--label-action
+     * the element with CSS class .filepond--label-action.
+     * @default 'Drag & Drop your files or <span class="filepond--label-action"> Browse </span>'
      */
     labelIdle: string;
-    /** Label shown when the field contains invalid files and is validated by the parent form */
+    /** 
+     * Label shown when the field contains invalid files and is validated by the parent form.
+     * @default 'Field contains invalid files'
+     */
     labelInvalidField: string;
-    /** Label used while waiting for file size information */
+    /** 
+     * Label used while waiting for file size information.
+     * @default 'Waiting for size'
+     */
     labelFileWaitingForSize: string;
-    /** Label used when no file size information was received */
+    /** 
+     * Label used when no file size information was received.
+     * @default 'Size not available'
+     */
     labelFileSizeNotAvailable: string;
-    /** Label used while loading a file */
+    /** 
+     * Label used while loading a file.
+     * @default 'Loading'
+     */
     labelFileLoading: string;
-    /** Label used when file load failed */
+    /** 
+     * Label used when file load failed.
+     * @default 'Error during load'
+     */
     labelFileLoadError: string;
-    /** Label used when uploading a file */
+    /** 
+     * Label used when uploading a file.
+     * @default 'Uploading'
+     */
     labelFileProcessing: string;
-    /** Label used when file upload has completed */
+    /** 
+     * Label used when file upload has completed.
+     * @default 'Upload complete'
+     */
     labelFileProcessingComplete: string;
-    /** Label used when upload was cancelled */
+    /** 
+     * Label used when upload was cancelled.
+     * @default 'Upload cancelled'
+     */
     labelFileProcessingAborted: string;
-    /** Label used when something went wrong during file upload */
+    /** 
+     * Label used when something went wrong during file upload.
+     * @default 'Error during upload'
+     */
     labelFileProcessingError: string;
-    /** Label used when something went wrong during reverting the file upload */
+    /** 
+     * Label used when something went wrong during reverting the file upload.
+     * @default 'Error during revert'
+     */
     labelFileProcessingRevertError: string;
-    /** Label used when something went during during removing the file upload */
+    /** 
+     * Label used when something went during during removing the file upload.
+     * @default 'Error during remove'
+     */
     labelFileRemoveError: string;
-    /** Label used to indicate to the user that an action can be cancelled. */
+    /** 
+     * Label used to indicate to the user that an action can be cancelled.
+     * @default 'tap to cancel'
+     */
     labelTapToCancel: string;
-    /** Label used to indicate to the user that an action can be retried. */
+    /** 
+     * Label used to indicate to the user that an action can be retried.
+     * @default 'tap to retry'
+     */
     labelTapToRetry: string;
-    /** Label used to indicate to the user that an action can be undone. */
+    /** 
+     * Label used to indicate to the user that an action can be undone.
+     * @default 'tap to undo'
+     */
     labelTapToUndo: string;
-    /** Label used for remove button */
+    /** 
+     * Label used for remove button.
+     * @default 'Remove'
+     */
     labelButtonRemoveItem: string;
-    /** Label used for abort load button */
+    /** 
+     * Label used for abort load button.
+     * @default 'Abort'
+     */
     labelButtonAbortItemLoad: string;
-    /** Label used for retry load button */
+    /** 
+     * Label used for retry load.
+     * @default 'Retry'
+     */
     labelButtonRetryItemLoad: string;
-    /** Label used for abort upload button */
+    /** 
+     * Label used for abort upload button.
+     * @default 'Cancel'
+     */
     labelButtonAbortItemProcessing: string;
-    /** Label used for undo upload button */
+    /** 
+     * Label used for undo upload button.
+     * @default 'Undo'
+     */
     labelButtonUndoItemProcessing: string;
-    /** Label used for retry upload button */
+    /** 
+     * Label used for retry upload button.
+     * @default 'Retry'
+     */
     labelButtonRetryItemProcessing: string;
-    /** Label used for upload button */
+    /** 
+     * Label used for upload button.
+     * @default 'Upload'
+     */
     labelButtonProcessItem: string;
 
-    /** The icon used for remove actions */
+    /** 
+     * The icon used for remove actions.
+     * @default '<svg></svg>'
+     */
     iconRemove: string;
-    /** The icon used for process actions */
+    /** 
+     * The icon used for process actions.
+     * @default '<svg></svg>'
+     */
     iconProcess: string;
-    /** The icon used for retry actions */
+    /** 
+     * The icon used for retry actions.
+     * @default '<svg></svg>'
+     */
     iconRetry: string;
-    /** The icon used for undo actions */
+     /** 
+      * The icon used for undo actions.
+      * @default '<svg></svg>'
+      */
     iconUndo: string;
 
     /** FilePond instance has been created and is ready. */
@@ -746,16 +1004,63 @@ export class FilePond {
     /* Called when a file is clicked or tapped **/
     onactivatefile?: (file: File) => void;
 
+    /**
+     * FilePond is about to allow this item to be dropped, it can be a URL or a File object.
+     * 
+     * Return `true` or `false` depending on if you want to allow the item to be dropped.
+     */
     beforeDropFile?: (file: File | string) => boolean;
+    /**
+     * FilePond is about to add this file. 
+     * 
+     * Return `false` to prevent adding it, or return a `Promise` and resolve with `true` or `false`.
+     */
     beforeAddFile?: (item: File) => boolean | Promise<boolean>;
+    /**
+     * FilePond is about to remove this file. 
+     * 
+     * Return `false` to prevent adding it, or return a `Promise` and resolve with `true` or `false`.
+     */
     beforeRemoveFile?: (item: File) => boolean | Promise<boolean>;
 
-    stylePanelLayout: 'integrated' | 'compact' | 'circle';
-    stylePanelAspectRatio: string;
-    styleItemPanelAspectRatio: string;
+    /** 
+     * Set a different layout render mode.
+     * @default null
+     */
+    stylePanelLayout: 'integrated' | 'compact' | 'circle' | null;
+    /**
+     * Set a forced aspect ratio for the FilePond drop area.
+     * 
+     * Accepts human readable aspect ratios like `1:1` or numeric aspect ratios like `0.75`.
+     * @default null
+     */
+    stylePanelAspectRatio: string | null;
+    /**
+     * Set a forced aspect ratio for the file items. 
+     * 
+     * Useful when rendering cropped or fixed aspect ratio images in grid view.
+     * @default null
+     */
+    styleItemPanelAspectRatio: string | null;
+    /** 
+     * The position of the remove item button
+     * @default 'left'
+     */
     styleButtonRemoveItemPosition: string;
+    /**
+     * The position of the remove item button.
+     * @default 'right' 
+     */
     styleButtonProcessItemPosition: string;
+    /**
+     * The position of the load indicator
+     * @default 'right'
+     */
     styleLoadIndicatorPosition: string;
+    /**
+     * The position of the progress indicator
+     * @default 'right'
+     */
     styleProgressIndicatorPosition: string;
 
     setOptions: (options: FilePondOptionProps) => void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -742,12 +742,12 @@ export class FilePond {
     /* Called when a file is clicked or tapped **/
     onactivatefile?: (file: File) => void;
 
-    beforeDropFile?: (file: File) => boolean;
+    beforeDropFile?: (file: File | string) => boolean;
     beforeAddFile?: (item: File) => boolean | Promise<boolean>;
     beforeRemoveFile?: (item: File) => boolean | Promise<boolean>;
 
     stylePanelLayout: 'integrated' | 'compact' | 'circle';
-    stylePanelAspectRatio: '3:2' | '1';
+    stylePanelAspectRatio: string;
     styleItemPanelAspectRatio: string;
     styleButtonRemoveItemPosition: string;
     styleButtonProcessItemPosition: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -33,25 +33,25 @@ export enum FileOrigin {
 type ActualFileObject = Blob & {readonly lastModified: number; readonly name: string; readonly size: number; readonly type: string};
 
 export class File {
-    /** Returns the ID of the file */
+    /** Returns the ID of the file. */
     id: string;
-    /** Returns the server id of the file */
+    /** Returns the server id of the file. */
     serverId: string;
-    /** Returns the origin of the file*/
+    /** Returns the origin of the file. */
     origin: 'input' | 'limbo' | 'local';
-    /** Returns the current status of the file */
+    /** Returns the current status of the file. */
     status: FileStatus;
-    /** Returns the File object */
+    /** Returns the File object. */
     file: ActualFileObject;
-    /** Returns the file extensions */
+    /** Returns the file extensions. */
     fileExtension: string;
-    /** Returns the size of the file */
+    /** Returns the size of the file. */
     fileSize: number;
-    /** Returns the type of the file */
+    /** Returns the type of the file. */
     fileType: string;
-    /** Returns the full name of the file */
+    /** Returns the full name of the file. */
     filename: string;
-    /** Returns the name of the file without extension */
+    /** Returns the name of the file without extension. */
     filenameWithoutExtension: string;
 
     /** Aborts loading of this file */
@@ -77,17 +77,17 @@ interface ServerUrl {
 
     /**
      * Called when server response is received, useful for getting
-     * the unique file id from the server response
+     * the unique file id from the server response.
      */
     onload?: () => any;
     /**
      * Called when server error is received, receives the response
-     * body, useful to select the relevant error data
+     * body, useful to select the relevant error data.
      */
     onerror?: (responseBody: any) => any;
     /**
      * Called with the formdata object right before it is sent,
-     * return extended formdata object to make changes
+     * return extended formdata object to make changes.
      */
     ondata?: (data: any) => any;
 }
@@ -99,16 +99,16 @@ type ProgressServerConfigFunction = (
      * false switches the FilePond loading indicator to infinite mode.
      */
     isLengthComputable: boolean,
-    /** The amount of data currently transferred */
+    /** The amount of data currently transferred .*/
     loadedDataAmount: number,
-    /** The total amount of data to be transferred */
+    /** The total amount of data to be transferred.*/
     totalDataAmount: number,
 ) => void;
 
 type ProcessServerConfigFunction = (
-    /** The name of the input field */
+    /** The name of the input field. */
     fieldName: string,
-    /** The actual file object to send */
+    /** The actual file object to send. */
     file: ActualFileObject,
     metadata: {[key: string]: any},
     /**
@@ -118,41 +118,41 @@ type ProcessServerConfigFunction = (
      * to the client.
      */
     load: (p: string | {[key: string]: any}) => void,
-    /** Can call the error method is something went wrong, should exit after */
+    /** Can call the error method is something went wrong, should exit after. */
     error: (errorText: string) => void,
     /**
-     * Should call the progress method to update the progress to 100% before calling load()
-     * Setting computable to false switches the loading indicator to infinite mode
+     * Should call the progress method to update the progress to 100% before calling load().
+     * Setting computable to false switches the loading indicator to infinite mode.
      */
     progress: ProgressServerConfigFunction,
-    /** Let FilePond know the request has been cancelled */
+    /** Let FilePond know the request has been cancelled. */
     abort: () => void
 ) => void;
 
 type RevertServerConfigFunction = (
-    /** Server file id of the file to restore */
+    /** Server file id of the file to restore. */
     uniqueFieldId: any,
-    /** Should call the load method when done */
+    /** Should call the load method when done. */
     load: () => void,
-    /** Can call the error method is something went wrong, should exit after */
+    /** Can call the error method is something went wrong, should exit after. */
     error: (errorText: string) => void,
 ) => void;
 
 type RestoreServerConfigFunction = (
     uniqueFileId: any,
-    /** Should call the load method with a file object or blob when done */
+    /** Should call the load method with a file object or blob when done. */
     load: (file: ActualFileObject) => void,
-    /** Can call the error method is something went wrong, should exit after */
+    /** Can call the error method is something went wrong, should exit after. */
     error: (errorText: string) => void,
     /**
-     * Should call the progress method to update the progress to 100% before calling load()
-     * Setting computable to false switches the loading indicator to infinite mode
+     * Should call the progress method to update the progress to 100% before calling load().
+     * Setting computable to false switches the loading indicator to infinite mode.
      */
     progress: ProgressServerConfigFunction,
-    /** Let FilePond know the request has been cancelled */
+    /** Let FilePond know the request has been cancelled. */
     abort: () => void,
     /**
-     * Can call the headers method to supply FilePond with early response header string
+     * Can call the headers method to supply FilePond with early response header string.
      * https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders
      */
     headers: (headersString: string) => void,
@@ -160,19 +160,19 @@ type RestoreServerConfigFunction = (
 
 type LoadServerConfigFunction = (
     source: any,
-    /** Should call the load method with a file object or blob when done */
+    /** Should call the load method with a file object or blob when done. */
     load: (file: ActualFileObject) => void,
-    /** Can call the error method is something went wrong, should exit after */
+    /** Can call the error method is something went wrong, should exit after. */
     error: (errorText: string) => void,
     /**
-     * Should call the progress method to update the progress to 100% before calling load()
-     * Setting computable to false switches the loading indicator to infinite mode
+     * Should call the progress method to update the progress to 100% before calling load().
+     * Setting computable to false switches the loading indicator to infinite mode.
      */
     progress: ProgressServerConfigFunction,
-    /** Let FilePond know the request has been cancelled */
+    /** Let FilePond know the request has been cancelled.*/
     abort: () => void,
     /**
-     * Can call the headers method to supply FilePond with early response header string
+     * Can call the headers method to supply FilePond with early response header string.
      * https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders>
      */
     headers: (headersString: string) => void,
@@ -180,37 +180,37 @@ type LoadServerConfigFunction = (
 
 type FetchServerConfigFunction = (
     url: string,
-    /** Should call the load method with a file object or blob when done */
+    /** Should call the load method with a file object or blob when done. */
     load: (file: ActualFileObject) => void,
-    /** Can call the error method is something went wrong, should exit after */
+    /** Can call the error method is something went wrong, should exit after. */
     error: (errorText: string) => void,
     /**
-     * Should call the progress method to update the progress to 100% before calling load()
-     * Setting computable to false switches the loading indicator to infinite mode
+     * Should call the progress method to update the progress to 100% before calling load().
+     * Setting computable to false switches the loading indicator to infinite mode.
      */
     progress: ProgressServerConfigFunction,
-    /** Let FilePond know the request has been cancelled */
+    /** Let FilePond know the request has been cancelled. */
     abort: () => void,
     /**
-     * Can call the headers method to supply FilePond with early response header string
+     * Can call the headers method to supply FilePond with early response header string.
      * https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders
      */
     headers: (headersString: string) => void,
 ) => void;
 
 interface FilePondInitialFile {
-    /** The server file reference */
+    /** The server file reference. */
     source: string;
     options: {
-        /** Origin of file being added */
+        /** Origin of file being added. */
         type: 'input' | 'limbo' | 'local';
-        /** Mock file information */
+        /** Mock file information. */
         file?: {
             name?: string;
             size?: number;
             type?: string;
         };
-        /** File initial metadata */
+        /** File initial metadata. */
         metadata?: {[key: string]: any};
     };
 }
@@ -231,7 +231,7 @@ interface FilePondServerConfigProps {
         fetch?: string | ServerUrl | FetchServerConfigFunction;
     };
     /** 
-     * Immediately upload new files to the server
+     * Immediately upload new files to the server.
      * @default true
      */
     instantUpload?: boolean;
@@ -434,7 +434,7 @@ interface FilePondCallbackProps {
      * FilePond instance throws a warning. For instance
      * when the maximum amount of files has been reached.
      * Optionally receives file if error is related to a
-     * file object
+     * file object.
      */
     onwarning?: (error: any, file?: File, status?: any) => void;
     /**
@@ -442,23 +442,23 @@ interface FilePondCallbackProps {
      * file if error is related to a file object.
      */
     onerror?: (file?: File, error?: FilePondErrorDescription, status?: any) => void;
-    /** Started file load */
+    /** Started file load. */
     onaddfilestart?: (file: File) => void;
-    /** Made progress loading a file */
+    /** Made progress loading a file. */
     onaddfileprogress?: (file: File, progress: number) => void;
-    /** If no error, file has been successfully loaded */
+    /** If no error, file has been successfully loaded. */
     onaddfile?: (file: File, error?: FilePondErrorDescription) => void;
-    /** Started processing a file */
+    /** Started processing a file. */
     onprocessfilestart?: (file: File) => void;
-    /** Made progress processing a file */
+    /** Made progress processing a file. */
     onprocessfileprogress?: (file: File, progress: number) => void;
-    /** Aborted processing of a file */
+    /** Aborted processing of a file. */
     onprocessfileabort?: (file: File) => void;
-    /** Processing of a file has been reverted */
+    /** Processing of a file has been reverted. */
     onprocessfilerevert?: (file: File) => void;
-    /** If no error, Processing of a file has been completed */
+    /** If no error, Processing of a file has been completed. */
     onprocessfile?: (file: File, error?: FilePondErrorDescription) => void;
-    /** Called when all files in the list have been processed */
+    /** Called when all files in the list have been processed. */
     onprocessfiles?: () => void;
     /** File has been removed. */
     onremovefile?: (file: File, error?: FilePondErrorDescription) => void;
@@ -468,9 +468,9 @@ interface FilePondCallbackProps {
      * It receives the file item and the output data.
      */
     onpreparefile?: (file: File, output: any) => void;
-    /** A file has been added or removed, receives a list of file items */
+    /** A file has been added or removed, receives a list of file items. */
     onupdatefiles?: (fileItems: File[]) => void;
-    /* Called when a file is clicked or tapped **/
+    /* Called when a file is clicked or tapped. **/
     onactivatefile?: (file: File) => void;
 }
 
@@ -516,7 +516,7 @@ interface FilePondStyleProps {
      */
     styleItemPanelAspectRatio?: string;
     /** 
-     * The position of the remove item button
+     * The position of the remove item button.
      * @default 'left'
      */
     styleButtonRemoveItemPosition?: string;
@@ -526,12 +526,12 @@ interface FilePondStyleProps {
      */
     styleButtonProcessItemPosition?: string;
     /**
-     * The position of the load indicator
+     * The position of the load indicator.
      * @default 'right'
      */
     styleLoadIndicatorPosition?: string;
     /**
-     * The position of the progress indicator
+     * The position of the progress indicator.
      * @default 'right'
      */
     styleProgressIndicatorPosition?: string;
@@ -541,43 +541,43 @@ type CaptureAttribute = "camera" | "microphone" | "camcorder";
 
 interface FilePondBaseProps {
     /** 
-     * The ID to add to the root element
+     * The ID to add to the root element.
      * @default null
      */
     id?: string;
     /**
-     * The input field name to use
+     * The input field name to use.
      * @default 'filepond'
      */
     name?: string;  
     /** 
-     * Class Name to put on wrapper 
+     * Class Name to put on wrapper.
      * @default null
      */
     className?: string;
     /** 
-     * Sets the required attribute to the output field
+     * Sets the required attribute to the output field.
      * @default false
      */
     required?: boolean;
     /**
-     * Sets the disabled attribute to the output field
+     * Sets the disabled attribute to the output field.
      * @default false
      */
     disabled?: boolean;
     /** 
-     * Sets the given value to the capture attribute
+     * Sets the given value to the capture attribute.
      * @default null
      */
     captureMethod?: CaptureAttribute;
 
     /** 
-     * Enable or disable drag n’ drop
+     * Enable or disable drag n’ drop.
      * @default true
      */
     allowDrop?: boolean;
     /** 
-     * Enable or disable file browser
+     * Enable or disable file browser.
      * @default true
      */
     allowBrowse?: boolean;
@@ -588,55 +588,55 @@ interface FilePondBaseProps {
      */
     allowPaste?: boolean;
     /** 
-     * Enable or disable adding multiple files
+     * Enable or disable adding multiple files.
      * @default false
      */
     allowMultiple?: boolean;
     /** 
-     * Allow drop to replace a file, only works when allowMultiple is false
+     * Allow drop to replace a file, only works when allowMultiple is false.
      * @default true
      */
     allowReplace?: boolean;
     /** 
-     * Allows the user to revert file upload
+     * Allows the user to revert file upload.
      * @default true
      */
     allowRevert?: boolean;
     /** 
-     * Require the file to be successfully reverted before continuing
+     * Require the file to be successfully reverted before continuing.
      * @default false
      */
     forceRevert?: boolean;
 
     /** 
-     * The maximum number of files that filepond pond can handle
+     * The maximum number of files that filepond pond can handle.
      * @default null
      */
     maxFiles?: number;
     /** 
-     * Enables custom validity messages
+     * Enables custom validity messages.
      * @default false
      */
     checkValidity?: boolean;
 
     /**
-     * Set to false to always add items to beginning or end of list
+     * Set to false to always add items to beginning or end of list.
      * @default true
      */
     itemInsertLocationFreedom?: boolean;
     /**
-     * Default index in list to add items that have been dropped at the top of the list
+     * Default index in list to add items that have been dropped at the top of the list.
      * @default 'before'
      */
     itemInsertLocation?: 'before' | 'after' | ((a: File, b: File) => number);
     /**
-     * The interval to use before showing each item being added to the list
+     * The interval to use before showing each item being added to the list.
      * @default 75
      */
     itemInsertInterval?: number;
 
     /** 
-     * The maximum number of files that can be uploaded in parallel
+     * The maximum number of files that can be uploaded in parallel.
      * @default null
      */
     maxParallelUploads?: number;
@@ -652,55 +652,83 @@ export interface FilePondOptionProps extends
     FilePondStyleProps,
     FilePondBaseProps {}
 
+type FilePondEventPrefixed = 'FilePond:init' 
+| 'FilePond:warning' 
+| 'FilePond:error' 
+| 'FilePond:addfilestart' 
+| 'FilePond:addfileprogress' 
+| 'FilePond:addfile'
+| 'FilePond:processfilestart' 
+| 'FilePond:processfileprogress' 
+| 'FilePond:processfileabort' 
+| 'FilePond:processfilerevert' 
+| 'FilePond:processfile' 
+| 'FilePond:removefile' 
+| 'FilePond:updatefiles'
+
+type FilePondEvent = 'init' 
+| 'warning' 
+| 'error' 
+| 'addfilestart' 
+| 'addfileprogress' 
+| 'addfile' 
+| 'processfilestart' 
+| 'processfileprogress' 
+| 'processfileabort'
+| 'processfilerevert'
+| 'processfile'
+| 'removefile'
+| 'updatefiles'
+
 export class FilePond {
     /**
-     * The root element of the Filepond instance
+     * The root element of the Filepond instance.
      */
     readonly element: Element | null;
     /**
-     * Returns the current status of the FilePond instance
+     * Returns the current status of the FilePond instance.
      * @default Status.EMPTY
      */
     readonly status: Status;
 
     /** 
-     * The ID to add to the root element
+     * The ID to add to the root element.
      * @default null
      */
     id: string | null;
     /**
-     * The input field name to use
+     * The input field name to use.
      * @default 'filepond'
      */
     name: string;  
     /** 
-     * Class Name to put on wrapper 
+     * Class Name to put on wrapper.
      * @default null
      */
     className: string | null;
     /** 
-     * Sets the required attribute to the output field
+     * Sets the required attribute to the output field.
      * @default false
      */
     required: boolean;
     /**
-     * Sets the disabled attribute to the output field
+     * Sets the disabled attribute to the output field.
      * @default false
      */
     disabled: boolean;
     /** 
-     * Sets the given value to the capture attribute
+     * Sets the given value to the capture attribute.
      * @default null
      */
     captureMethod: CaptureAttribute | null;
 
     /** 
-     * Enable or disable drag n’ drop
+     * Enable or disable drag n’ drop.
      * @default true
      */
     allowDrop: boolean;
     /** 
-     * Enable or disable file browser
+     * Enable or disable file browser.
      * @default true
      */
     allowBrowse: boolean;
@@ -711,55 +739,55 @@ export class FilePond {
      */
     allowPaste: boolean;
     /** 
-     * Enable or disable adding multiple files
+     * Enable or disable adding multiple files.
      * @default false
      */
     allowMultiple: boolean;
     /** 
-     * Allow drop to replace a file, only works when allowMultiple is false
+     * Allow drop to replace a file, only works when allowMultiple is false.
      * @default true
      */
     allowReplace: boolean;
     /** 
-     * Allows the user to revert file upload
+     * Allows the user to revert file upload.
      * @default true
      */
     allowRevert: boolean;
     /** 
-     * Require the file to be successfully reverted before continuing
+     * Require the file to be successfully reverted before continuing.
      * @default false
      */
     forceRevert: boolean;
 
     /** 
-     * The maximum number of files that filepond pond can handle
+     * The maximum number of files that filepond pond can handle.
      * @default null
      */
     maxFiles: number | null;
     /** 
-     * Enables custom validity messages
+     * Enables custom validity messages.
      * @default false
      */
     checkValidity: boolean;
 
     /**
-     * Set to false to always add items to beginning or end of list
+     * Set to false to always add items to beginning or end of list.
      * @default true
      */
     itemInsertLocationFreedom: boolean;
     /**
-     * Default index in list to add items that have been dropped at the top of the list
+     * Default index in list to add items that have been dropped at the top of the list.
      * @default 'before'
      */
     itemInsertLocation: 'before' | 'after' | ((a: File, b: File) => number);
     /**
-     * The interval to use before showing each item being added to the list
+     * The interval to use before showing each item being added to the list.
      * @default 75
      */
     itemInsertInterval: number;
 
     /** 
-     * The maximum number of files that can be uploaded in parallel
+     * The maximum number of files that can be uploaded in parallel.
      * @default null
      */
     maxParallelUploads: number | null;   
@@ -801,8 +829,9 @@ export class FilePond {
         load?: string | ServerUrl | LoadServerConfigFunction;
         fetch?: string | ServerUrl | FetchServerConfigFunction;
     } | null;
+
     /** 
-     * Immediately upload new files to the server
+     * Immediately upload new files to the server.
      * @default true
      */
     instantUpload?: boolean;
@@ -965,7 +994,7 @@ export class FilePond {
      * FilePond instance throws a warning. For instance
      * when the maximum amount of files has been reached.
      * Optionally receives file if error is related to a
-     * file object
+     * file object.
      */
     onwarning?: (error: any, file?: File, status?: any) => void;
     /**
@@ -973,23 +1002,23 @@ export class FilePond {
      * file if error is related to a file object.
      */
     onerror?: (file?: File, error?: FilePondErrorDescription, status?: any) => void;
-    /** Started file load */
+    /** Started file load. */
     onaddfilestart?: (file: File) => void;
-    /** Made progress loading a file */
+    /** Made progress loading a file. */
     onaddfileprogress?: (file: File, progress: number) => void;
-    /** If no error, file has been successfully loaded */
+    /** If no error, file has been successfully loaded. */
     onaddfile?: (file: File, error?: FilePondErrorDescription) => void;
-    /** Started processing a file */
+    /** Started processing a file. */
     onprocessfilestart?: (file: File) => void;
-    /** Made progress processing a file */
+    /** Made progress processing a file. */
     onprocessfileprogress?: (file: File, progress: number) => void;
-    /** Aborted processing of a file */
+    /** Aborted processing of a file. */
     onprocessfileabort?: (file: File) => void;
-    /** Processing of a file has been reverted */
+    /** Processing of a file has been reverted. */
     onprocessfilerevert?: (file: File) => void;
-    /** If no error, Processing of a file has been completed */
+    /** If no error, Processing of a file has been completed. */
     onprocessfile?: (file: File, error?: FilePondErrorDescription) => void;
-    /** Called when all files in the list have been processed */
+    /** Called when all files in the list have been processed. */
     onprocessfiles?: () => void;
     /** File has been removed. */
     onremovefile?: (file: File, error?: FilePondErrorDescription) => void;
@@ -999,9 +1028,9 @@ export class FilePond {
      * It receives the file item and the output data.
      */
     onpreparefile?: (file: File, output: any) => void;
-    /** A file has been added or removed, receives a list of file items */
+    /** A file has been added or removed, receives a list of file items. */
     onupdatefiles?: (fileItems: File[]) => void;
-    /* Called when a file is clicked or tapped **/
+    /* Called when a file is clicked or tapped. **/
     onactivatefile?: (file: File) => void;
 
     /**
@@ -1043,7 +1072,7 @@ export class FilePond {
      */
     styleItemPanelAspectRatio: string | null;
     /** 
-     * The position of the remove item button
+     * The position of the remove item button.
      * @default 'left'
      */
     styleButtonRemoveItemPosition: string;
@@ -1053,66 +1082,123 @@ export class FilePond {
      */
     styleButtonProcessItemPosition: string;
     /**
-     * The position of the load indicator
+     * The position of the load indicator.
      * @default 'right'
      */
     styleLoadIndicatorPosition: string;
     /**
-     * The position of the progress indicator
+     * The position of the progress indicator.
      * @default 'right'
      */
     styleProgressIndicatorPosition: string;
 
+    /** Override multiple options at once. */
     setOptions: (options: FilePondOptionProps) => void;
+    /** 
+     * Adds a file.
+     * @param options.index The index that the file should be added at.
+     */
     addFile: (source: ActualFileObject | Blob | string, options?: {index: number}) => Promise<File>;
+    /** 
+     * Adds multiple files.
+     * @param options.index The index that the files should be added at.
+     */
     addFiles: (source: ActualFileObject[] | Blob[] | string[], options?: {index: number}) => Promise<File[]>;
+    /** 
+     * Removes a file. If no parameter is provided, removes the first file in the list.
+     * @param query The file reference, id, or index.
+     */
     removeFile: (query?: File | string | number) => void;
+    /** Removes all files. */
     removeFiles: () => void;
+    /** 
+     * Processes a file. If no parameter is provided, processes the first file in the list.
+     * @param query The file reference, id, or index
+     */
     processFile: (query?: File | string | number) => Promise<File>;
-    processFiles: () => Promise<File[]>;
-    getFile: () => File;
+    /**
+     * Processes multiple files. If no parameter is provided, processes all files.
+     * @param query The file reference(s), id(s), or index(es)
+     */
+    processFiles: (query?: File[] | string[] | number[]) => Promise<File[]>;
+    /** 
+     * Returns a file. If no parameter is provided, returns the first file in the list.
+     * @param query The file id, or index
+     */
+    getFile: (query?: string | number) => File;
+    /** Returns all files. */
     getFiles: () => File[];
+    /**
+     * Manually trigger the browse files panel.
+     * 
+     * Only works if the call originates from the user.
+     */
     browse: () => void;
+    /**
+     * Sort the items in the files list.
+     * @param compare The comparison function
+     */
     sort: (compare: (a: File, b: File) => number) => void;
+    /** Destroys this FilePond instance. */
     destroy: () => void;
 
-    /** Inserts the FilePond instance after the supplied element */
+    /** Inserts the FilePond instance after the supplied element. */
     insertAfter: (element: Element) => void;
-    /** Inserts the FilePond instance before the supplied element */
+    /** Inserts the FilePond instance before the supplied element. */
     insertBefore: (element: Element) => void;
-    /** Appends FilePond to the given element  */
+    /** Appends FilePond to the given element.  */
     appendTo: (element: Element) => void;
-    /** Returns true if the current instance is attached to the supplied element */
+    /** Returns true if the current instance is attached to the supplied element. */
     isAttachedTo: (element: Element) => void;
-    /** Replaces the supplied element with FilePond */
+    /** Replaces the supplied element with FilePond. */
     replaceElement: (element: Element) => void;
-    /** If FilePond replaced the original element, this restores the original element to its original glory */
+    /** If FilePond replaced the original element, this restores the original element to its original glory. */
     restoreElement: (element: Element) => void;
 
-    addEventListener: (event: string, fn: (...args: any[]) => void) => void;
-    on: (event: string, fn: (...args: any[]) => void) => void;
-    onOnce: (event: string, fn: (...args: any[]) => void) => void;
-    off: (event: string, fn: (...args: any[]) => void) => void;  
+    /** 
+     * Adds an event listener to the given event.
+     * @param event Name of the event, prefixed with `Filepond:`
+     * @param fn Event handler
+     */
+    addEventListener: (event: FilePondEventPrefixed, fn: (e: any) => void) => void;
+    /** 
+     * Listen to an event.
+     * @param event Name of the event
+     * @param fn Event handler, signature is identical to the callback method
+     */
+    on: (event: FilePondEvent, fn: (...args: any[]) => void) => void;
+     /** 
+     * Listen to an event once and remove the handler.
+     * @param event Name of the event
+     * @param fn Event handler, signature is identical to the callback method
+     */
+    onOnce: (event: FilePondEvent, fn: (...args: any[]) => void) => void;
+     /** 
+     * Stop listening to an event.
+     * @param event Name of the event
+     * @param fn Event handler, signature is identical to the callback method
+     */
+    off: (event: FilePondEvent, fn: (...args: any[]) => void) => void;  
 }
 
-/** Creates a new FilePond instance */
+/** Creates a new FilePond instance. */
 export function create(element?: Element, options?: FilePondOptionProps): FilePond;
-/** Destroys the FilePond instance attached to the supplied element */
+/** Destroys the FilePond instance attached to the supplied element. */
 export function destroy(element: Element): void;
-/** Returns the FilePond instance attached to the supplied element */
+/** Returns the FilePond instance attached to the supplied element. */
 export function find(element: Element): FilePond;
 /**
  * Parses a given section of the DOM tree for elements with class
  * .filepond and turns them into FilePond elements.
  */
 export function parse(context: Element): void;
-/** Registers a FilePond plugin for later use */
+/** Registers a FilePond plugin for later use. */
 export function registerPlugin(...plugins: any[]): void;
-/** Sets page level default options for all FilePond instances */
+/** Sets page level default options for all FilePond instances. */
 export function setOptions(options: FilePondOptionProps): void;
-/** Returns the current default options */
+/** Returns the current default options. */
 export function getOptions(): FilePondOptionProps;
-/** Determines whether or not the browser supports FilePond */
+/** Determines whether or not the browser supports FilePond. */
 export function supported(): boolean;
-/** Returns an object describing all the available options and their types, useful for writing FilePond adapters */
+/** Returns an object describing all the available options and their types, useful for writing FilePond adapters. */
 export const OptionTypes: object;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -118,7 +118,7 @@ type ProcessServerConfigFunction = (
      * to the client.
      */
     load: (p: string | { [key: string]: any }) => void,
-    /** Can call the error method is something went wrong, should exit after. */
+    /** Call if something goes wrong, will exit after. */
     error: (errorText: string) => void,
     /**
      * Should call the progress method to update the progress to 100% before calling load().
@@ -134,15 +134,16 @@ type RevertServerConfigFunction = (
     uniqueFieldId: any,
     /** Should call the load method when done. */
     load: () => void,
-    /** Can call the error method is something went wrong, should exit after. */
-    error: (errorText: string) => void,
+    /** Call if something goes wrong, will exit after. */
+    error: (errorText: string) => void
 ) => void;
 
 type RestoreServerConfigFunction = (
+    /** Server file id of the file to restore. */
     uniqueFileId: any,
     /** Should call the load method with a file object or blob when done. */
     load: (file: ActualFileObject) => void,
-    /** Can call the error method is something went wrong, should exit after. */
+    /** Call if something goes wrong, will exit after. */
     error: (errorText: string) => void,
     /**
      * Should call the progress method to update the progress to 100% before calling load().
@@ -155,14 +156,14 @@ type RestoreServerConfigFunction = (
      * Can call the headers method to supply FilePond with early response header string.
      * https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders
      */
-    headers: (headersString: string) => void,
+    headers: (headersString: string) => void
 ) => void;
 
 type LoadServerConfigFunction = (
     source: any,
     /** Should call the load method with a file object or blob when done. */
     load: (file: ActualFileObject) => void,
-    /** Can call the error method is something went wrong, should exit after. */
+    /** Call if something goes wrong, will exit after. */
     error: (errorText: string) => void,
     /**
      * Should call the progress method to update the progress to 100% before calling load().
@@ -175,14 +176,14 @@ type LoadServerConfigFunction = (
      * Can call the headers method to supply FilePond with early response header string.
      * https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders>
      */
-    headers: (headersString: string) => void,
+    headers: (headersString: string) => void
 ) => void;
 
 type FetchServerConfigFunction = (
     url: string,
     /** Should call the load method with a file object or blob when done. */
     load: (file: ActualFileObject) => void,
-    /** Can call the error method is something went wrong, should exit after. */
+    /** Call if something goes wrong, will exit after. */
     error: (errorText: string) => void,
     /**
      * Should call the progress method to update the progress to 100% before calling load().
@@ -195,7 +196,16 @@ type FetchServerConfigFunction = (
      * Can call the headers method to supply FilePond with early response header string.
      * https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders
      */
-    headers: (headersString: string) => void,
+    headers: (headersString: string) => void
+) => void;
+
+type RemoveServerConfigFunction = (
+    /** Local file source */
+    source: any,
+    /** Call when done */
+    load: () => void,
+    /** Call if something goes wrong, will exit after. */
+    error: (errorText: string) => void
 ) => void;
 
 interface FilePondInitialFile {
@@ -224,11 +234,12 @@ interface FilePondServerConfigProps {
     server?: string | {
         url?: string
         timeout?: number
-        process?: string | ServerUrl | ProcessServerConfigFunction;
-        revert?: string | ServerUrl | RevertServerConfigFunction;
-        restore?: string | ServerUrl | RestoreServerConfigFunction;
-        load?: string | ServerUrl | LoadServerConfigFunction;
-        fetch?: string | ServerUrl | FetchServerConfigFunction;
+        process?: string | ServerUrl | ProcessServerConfigFunction | null;
+        revert?: string | ServerUrl | RevertServerConfigFunction | null;
+        restore?: string | ServerUrl | RestoreServerConfigFunction | null;
+        load?: string | ServerUrl | LoadServerConfigFunction | null;
+        fetch?: string | ServerUrl | FetchServerConfigFunction | null;
+        remove?: RemoveServerConfigFunction | null;
     };
     /**
      * Immediately upload new files to the server.
@@ -825,11 +836,12 @@ export class FilePond {
     server?: string | {
         url?: string
         timeout?: number
-        process?: string | ServerUrl | ProcessServerConfigFunction;
-        revert?: string | ServerUrl | RevertServerConfigFunction;
-        restore?: string | ServerUrl | RestoreServerConfigFunction;
-        load?: string | ServerUrl | LoadServerConfigFunction;
-        fetch?: string | ServerUrl | FetchServerConfigFunction;
+        process?: string | ServerUrl | ProcessServerConfigFunction | null;
+        revert?: string | ServerUrl | RevertServerConfigFunction | null;
+        restore?: string | ServerUrl | RestoreServerConfigFunction | null;
+        load?: string | ServerUrl | LoadServerConfigFunction | null;
+        fetch?: string | ServerUrl | FetchServerConfigFunction | null;
+        remove: RemoveServerConfigFunction | null;
     } | null;
 
     /** 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -79,17 +79,17 @@ interface ServerUrl {
      * Called when server response is received, useful for getting
      * the unique file id from the server response.
      */
-    onload?: () => any;
+    onload?: (response: any) => void;
     /**
      * Called when server error is received, receives the response
      * body, useful to select the relevant error data.
      */
-    onerror?: (responseBody: any) => any;
+    onerror?: (responseBody: any) => void;
     /**
      * Called with the formdata object right before it is sent,
      * return extended formdata object to make changes.
      */
-    ondata?: (data: any) => any;
+    ondata?: (data: FormData) => FormData;
 }
 
 type ProgressServerConfigFunction = (

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,3 @@
-// Type definitions for Filepond <https://github.com/pqina/filepond>
 // Based on definitions by Zach Posten for React-Filepond <https://github.com/zposten>
 // Updated by Hawxy <https://github.com/Hawxy>
 // TypeScript Version: 3.5
@@ -338,7 +337,7 @@ interface FilePondCallbackProps {
 
 interface FilePondHookProps {
     beforeDropFile?: (file: File) => boolean;
-    beforeAddFile?: (item: File) => false | Promise<boolean>
+    beforeAddFile?: (item: File) => false | Promise<boolean>;
     beforeRemoveFile?: (item: File) => false | Promise<boolean>;
 }
 
@@ -393,8 +392,8 @@ export interface FilePondProps extends
 
 export class FilePond {
     setOptions: (options: FilePondProps) => void;
-    addFile: (source: File, option?: {index: number}) => Promise<File[]>;
-    addFiles: (source: File[], option?: {index: number}) => Promise<File[]>;
+    addFile: (source: File, options?: {index: number}) => Promise<File[]>;
+    addFiles: (source: File[], options?: {index: number}) => Promise<File[]>;
     removeFile: (query?: string | number) => void;
     removeFiles: () => void;
     processFile: (query?: string | number) => Promise<File>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,8 +1,9 @@
-//Type definitions for Filepond <https://github.com/pqina/filepond>
-//Based on definitions by Zach Posten for React-Filepond <https://github.com/zposten>
-//Updated by Hawxy <https://github.com/Hawxy>
-// TypeScript Version: 3.5.2
+// Type definitions for Filepond <https://github.com/pqina/filepond>
+// Based on definitions by Zach Posten for React-Filepond <https://github.com/zposten>
+// Updated by Hawxy <https://github.com/Hawxy>
+// TypeScript Version: 3.5
 
+export {};
 
 type FilePondOrigin =
     | 'input' // Added by user
@@ -10,28 +11,31 @@ type FilePondOrigin =
     | 'local' // Existing server file
     ;
 
-export interface FileProps {
-    src: string;
-    name?: string;
-    size?: number;
-    type?: string;
-    origin?: FilePondOrigin;
-    metadata?: {[key: string]: any};
+export enum FileStatus {
+    INIT = 1,
+    IDLE = 2,
+    PROCESSING_QUEUED = 9,
+    PROCESSING = 3,
+    PROCESSING_COMPLETE = 5,
+    PROCESSING_ERROR = 6,
+    PROCESSING_REVERT_ERROR = 10,
+    LOADING = 7,
+    LOAD_ERROR = 8
 }
 
 type ActualFileObject = Blob & {readonly lastModified: number; readonly name: string};
 
 export class File {
-    file: ActualFileObject;
-    fileSize: number;
-    fileType: string;
-    filename: string;
-    fileExtension: string;
-    filenameWithoutExtension: string;
     id: string;
     serverId: string;
-    status: number;
-    archived: boolean;
+    origin: FilePondOrigin;  
+    status: FileStatus;  
+    file: ActualFileObject;
+    fileExtension: string;
+    fileSize: number;
+    fileType: string;
+    filename: string;   
+    filenameWithoutExtension: string; 
 
     /** Aborts loading of this file */
     abortLoad: () => void;
@@ -329,7 +333,9 @@ interface FilePondCallbackProps {
 }
 
 interface FilePondHookProps {
-    beforeRemoveFile?: (file: File) => boolean;
+    beforeDropFile?: (file: File) => boolean;
+    beforeAddFile?: (item: File) => false | Promise<boolean>
+    beforeRemoveFile?: (item: File) => false | Promise<boolean>;
 }
 
 interface FilePondBaseProps {
@@ -361,12 +367,10 @@ interface FilePondBaseProps {
     /** Require the file to be reverted before removal */
     forceRevert?: boolean;
 
-
     /** The maximum number of files that filepond pond can handle */
     maxFiles?: number;
     /** Enables custom validity messages */
     checkValidity?: boolean;
-
 
     /** The maximum number of files that can be uploaded in parallel */
     maxParallelUploads?: number;
@@ -385,12 +389,12 @@ export interface FilePondProps extends
 
 export class FilePond {
     setOptions: (options: FilePondProps) => void;
-    addFile: (source: File) => void;
-    addFiles: (source: File[]) => void;
-    removeFile: (query: string) => void;
+    addFile: (source: File, option?: {index: number}) => Promise<File[]>;
+    addFiles: (source: File[], option?: {index: number}) => Promise<File[]>;
+    removeFile: (query?: string | number) => void;
     removeFiles: () => void;
-    processFile: (query: string) => void;
-    processFiles: () => void;
+    processFile: (query?: string | number) => Promise<File>;
+    processFiles: () => Promise<File[]>;
     getFile: () => File;
     getFiles: () => File[];
     browse: () => void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -405,7 +405,7 @@ export class FilePond {
 }
 
 /** Creates a new FilePond instance */
-export function create(element?: any, options?: FilePondProps): void;
+export function create(element?: any, options?: FilePondProps): FilePond;
 /** Destroys the FilePond instance attached to the supplied element */
 export function destroy(element: any): void;
 /** Returns the FilePond instance attached to the supplied element */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -188,8 +188,20 @@ type FetchServerConfigFunction = (
     headers: (headersString: string) => void,
 ) => void;
 
+interface FilePondInitialFile {
+    source: string;
+    options: {
+        type: 'input' | 'limbo' | 'local';
+        file?: {
+            name?: string;
+            size?: number;
+            type?: string;
+        };
+        metadata?: {[key: string]: any};
+    };
+}
+
 interface FilePondServerConfigProps {
-    instantUpload?: boolean;
     server?: string | {
         url?: string
         timeout?: number
@@ -199,6 +211,8 @@ interface FilePondServerConfigProps {
         load?: string | ServerUrl | LoadServerConfigFunction;
         fetch?: string | ServerUrl | FetchServerConfigFunction;
     };
+    instantUpload?: boolean;
+    files?: FilePondInitialFile[] | ActualFileObject[] | Blob[] | string[];
 }
 
 interface FilePondDragDropProps {
@@ -288,24 +302,6 @@ interface FilePondSvgIconProps {
     iconRetry?: string;
      /** The icon used for undo actions */
     iconUndo?: string;
-}
-
-interface FilePondInitialFile {
-    source: string;
-    options: {
-        type: 'input' | 'limbo' | 'local';
-        file?: {
-            name?: string;
-            size?: number;
-            type?: string;
-        };
-        metadata?: {[key: string]: any};
-    };
-}
-
-interface FilePondFileProps {
-    /** Array of initial files */
-    files?: FilePondInitialFile[] | ActualFileObject[] | Blob[] | string[];
 }
 
 interface FilePondErrorDescription {
@@ -434,7 +430,6 @@ export interface FilePondOptionProps extends
     FilePondCallbackProps,
     FilePondHookProps,
     FilePondStyleProps,
-    FilePondFileProps,
     FilePondBaseProps {}
 
 export class FilePond {
@@ -466,6 +461,7 @@ export class FilePond {
     dropValidation: false;
     ignoredFiles: string[];
 
+    instantUpload: boolean;
     server: string | {
         url?: string
         timeout?: number
@@ -474,8 +470,7 @@ export class FilePond {
         restore?: string | ServerUrl | RestoreServerConfigFunction;
         load?: string | ServerUrl | LoadServerConfigFunction;
         fetch?: string | ServerUrl | FetchServerConfigFunction;
-    } | null;
-    instantUpload: boolean;
+    } | null;   
     files: FilePondInitialFile[] | ActualFileObject[] | Blob[] | string[];
 
     /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -337,8 +337,26 @@ interface FilePondCallbackProps {
 
 interface FilePondHookProps {
     beforeDropFile?: (file: File) => boolean;
-    beforeAddFile?: (item: File) => false | Promise<boolean>;
-    beforeRemoveFile?: (item: File) => false | Promise<boolean>;
+    beforeAddFile?: (item: File) => boolean | Promise<boolean>;
+    beforeRemoveFile?: (item: File) => boolean | Promise<boolean>;
+}
+
+interface FilePondMockFileProps {
+    source: string,
+    options: {
+        type: FilePondOrigin,
+        file?: {
+            name?: string,
+            size?: number,
+            type?: string
+        },
+        metadata?: {[key: string]: any};
+    }
+}
+
+interface FilePondFileProps {
+    /** Array of initial files */
+    files?: FilePondMockFileProps[]
 }
 
 interface FilePondBaseProps {
@@ -378,7 +396,6 @@ interface FilePondBaseProps {
     /** The maximum number of files that can be uploaded in parallel */
     maxParallelUploads?: number;
     acceptedFileTypes?: string[];
-    metadata?: {[key: string]: any};
 }
 
 export interface FilePondProps extends
@@ -388,6 +405,7 @@ export interface FilePondProps extends
     FilePondSvgIconProps,
     FilePondCallbackProps,
     FilePondHookProps,
+    FilePondFileProps,
     FilePondBaseProps {}
 
 export class FilePond {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -33,15 +33,25 @@ export enum FileOrigin {
 type ActualFileObject = Blob & {readonly lastModified: number; readonly name: string; readonly size: number; readonly type: string};
 
 export class File {
+    /** Returns the ID of the file */
     id: string;
+    /** Returns the server id of the file */
     serverId: string;
+    /** Returns the origin of the file*/
     origin: FileOrigin;
+    /** Returns the current status of the file */
     status: FileStatus;
+    /** Returns the File object */
     file: ActualFileObject;
+    /** Returns the file extensions */
     fileExtension: string;
+    /** Returns the size of the file */
     fileSize: number;
+    /** Returns the type of the file */
     fileType: string;
+    /** Returns the full name of the file */
     filename: string;
+    /** Returns the name of the file without extension */
     filenameWithoutExtension: string;
 
     /** Aborts loading of this file */
@@ -202,6 +212,11 @@ interface FilePondInitialFile {
 }
 
 interface FilePondServerConfigProps {
+    /** 
+     * Server API Configuration.
+     * See: https://pqina.nl/filepond/docs/patterns/api/server
+     * @default null
+     */
     server?: string | {
         url?: string
         timeout?: number
@@ -211,23 +226,39 @@ interface FilePondServerConfigProps {
         load?: string | ServerUrl | LoadServerConfigFunction;
         fetch?: string | ServerUrl | FetchServerConfigFunction;
     };
+    /** 
+     * Immediately upload new files to the server
+     * @default true
+     */
     instantUpload?: boolean;
+    /**
+     * A list of file locations that should be loaded immediately.
+     * See: https://pqina.nl/filepond/docs/patterns/api/filepond-object/#setting-initial-files
+     * @default []
+     */
     files?: FilePondInitialFile[] | ActualFileObject[] | Blob[] | string[];
 }
 
 interface FilePondDragDropProps {
-    /** FilePond will catch all files dropped on the webpage */
+    /** 
+     * FilePond will catch all files dropped on the webpage.
+     * @default false
+     */
     dropOnPage?: boolean;
-    /** Require drop on the FilePond element itself to catch the file. */
+    /** Require drop on the FilePond element itself to catch the file.
+     * @default true
+    */
     dropOnElement?: boolean;
     /**
      * When enabled, files are validated before they are dropped.
      * A file is not added when it’s invalid.
+     * @default false
      */
     dropValidation?: boolean;
     /**
      * Ignored file names when handling dropped directories.
      * Dropping directories is not supported on all browsers.
+     * @default ['.ds_store', 'thumbs.db', 'desktop.ini']
      */
     ignoredFiles?: string[];
 }
@@ -236,71 +267,149 @@ interface FilePondLabelProps {
     /**
      * The decimal separator used to render numbers.
      * By default this is determined automatically.
+     * @default 'auto'
      */
     labelDecimalSeparator?: string;
     /**
      * The thousands separator used to render numbers.
      * By default this is determined automatically.
+     * @default 'auto'
      */
     labelThousandsSeparator?: string;
     /**
      * Default label shown to indicate this is a drop area.
      * FilePond will automatically bind browse file events to
-     * the element with CSS class .filepond--label-action
+     * the element with CSS class .filepond--label-action.
+     * @default 'Drag & Drop your files or <span class="filepond--label-action"> Browse </span>'
      */
     labelIdle?: string;
-    /** Label shown when the field contains invalid files and is validated by the parent form */
+    /** 
+     * Label shown when the field contains invalid files and is validated by the parent form.
+     * @default 'Field contains invalid files'
+     */
     labelInvalidField?: string;
-    /** Label used while waiting for file size information */
+    /** 
+     * Label used while waiting for file size information.
+     * @default 'Waiting for size'
+     */
     labelFileWaitingForSize?: string;
-    /** Label used when no file size information was received */
+    /** 
+     * Label used when no file size information was received.
+     * @default 'Size not available'
+     */
     labelFileSizeNotAvailable?: string;
-    /** Label used while loading a file */
+    /** 
+     * Label used while loading a file.
+     * @default 'Loading'
+     */
     labelFileLoading?: string;
-    /** Label used when file load failed */
+    /** 
+     * Label used when file load failed.
+     * @default 'Error during load'
+     */
     labelFileLoadError?: string;
-    /** Label used when uploading a file */
+    /** 
+     * Label used when uploading a file.
+     * @default 'Uploading'
+     */
     labelFileProcessing?: string;
-    /** Label used when file upload has completed */
+    /** 
+     * Label used when file upload has completed.
+     * @default 'Upload complete'
+     */
     labelFileProcessingComplete?: string;
-    /** Label used when upload was cancelled */
+    /** 
+     * Label used when upload was cancelled.
+     * @default 'Upload cancelled'
+     */
     labelFileProcessingAborted?: string;
-    /** Label used when something went wrong during file upload */
+    /** 
+     * Label used when something went wrong during file upload.
+     * @default 'Error during upload'
+     */
     labelFileProcessingError?: string;
-    /** Label used when something went wrong during reverting the file upload */
+    /** 
+     * Label used when something went wrong during reverting the file upload.
+     * @default 'Error during revert'
+     */
     labelFileProcessingRevertError?: string;
-    /** Label used when something went during during removing the file upload */
+    /** 
+     * Label used when something went during during removing the file upload.
+     * @default 'Error during remove'
+     */
     labelFileRemoveError?: string;
-    /** Label used to indicate to the user that an action can be cancelled. */
+    /** 
+     * Label used to indicate to the user that an action can be cancelled.
+     * @default 'tap to cancel'
+     */
     labelTapToCancel?: string;
-    /** Label used to indicate to the user that an action can be retried. */
+    /** 
+     * Label used to indicate to the user that an action can be retried.
+     * @default 'tap to retry'
+     */
     labelTapToRetry?: string;
-    /** Label used to indicate to the user that an action can be undone. */
+    /** 
+     * Label used to indicate to the user that an action can be undone.
+     * @default 'tap to undo'
+     */
     labelTapToUndo?: string;
-    /** Label used for remove button */
+    /** 
+     * Label used for remove button.
+     * @default 'Remove'
+     */
     labelButtonRemoveItem?: string;
-    /** Label used for abort load button */
+    /** 
+     * Label used for abort load button.
+     * @default 'Abort'
+     */
     labelButtonAbortItemLoad?: string;
-    /** Label used for retry load button */
+    /** 
+     * Label used for retry load.
+     * @default 'Retry'
+     */
     labelButtonRetryItemLoad?: string;
-    /** Label used for abort upload button */
+    /** 
+     * Label used for abort upload button.
+     * @default 'Cancel'
+     */
     labelButtonAbortItemProcessing?: string;
-    /** Label used for undo upload button */
+    /** 
+     * Label used for undo upload button.
+     * @default 'Undo'
+     */
     labelButtonUndoItemProcessing?: string;
-    /** Label used for retry upload button */
+    /** 
+     * Label used for retry upload button.
+     * @default 'Retry'
+     */
     labelButtonRetryItemProcessing?: string;
-    /** Label used for upload button */
+    /** 
+     * Label used for upload button.
+     * @default 'Upload'
+     */
     labelButtonProcessItem?: string;
 }
 
 interface FilePondSvgIconProps {
-    /** The icon used for remove actions */
+    /** 
+     * The icon used for remove actions.
+     * @default '<svg></svg>'
+     */
     iconRemove?: string;
-    /** The icon used for process actions */
+    /** 
+     * The icon used for process actions.
+     * @default '<svg></svg>'
+     */
     iconProcess?: string;
-    /** The icon used for retry actions */
+    /** 
+     * The icon used for retry actions.
+     * @default '<svg></svg>'
+     */
     iconRetry?: string;
-     /** The icon used for undo actions */
+     /** 
+      * The icon used for undo actions.
+      * @default '<svg></svg>'
+      */
     iconUndo?: string;
 }
 
@@ -649,3 +758,5 @@ export function setOptions(options: FilePondOptionProps): void;
 export function getOptions(): FilePondOptionProps;
 /** Determines whether or not the browser supports FilePond */
 export function supported(): boolean;
+/** Returns an object describing all the available options and their types, useful for writing FilePond adapters */
+export const OptionTypes: object;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -38,7 +38,7 @@ export class File {
     /** Returns the server id of the file */
     serverId: string;
     /** Returns the origin of the file*/
-    origin: FileOrigin;
+    origin: 'input' | 'limbo' | 'local';
     /** Returns the current status of the file */
     status: FileStatus;
     /** Returns the File object */
@@ -199,14 +199,18 @@ type FetchServerConfigFunction = (
 ) => void;
 
 interface FilePondInitialFile {
+    /** The server file reference */
     source: string;
     options: {
+        /** Origin of file being added */
         type: 'input' | 'limbo' | 'local';
+        /** Mock file information */
         file?: {
             name?: string;
             size?: number;
             type?: string;
         };
+        /** File initial metadata */
         metadata?: {[key: string]: any};
     };
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,12 +4,6 @@
 
 export {};
 
-type FilePondOrigin =
-    | 'input' // Added by user
-    | 'limbo' // Temporary server file
-    | 'local' // Existing server file
-    ;
-
 export enum FileStatus {
     INIT = 1,
     IDLE = 2,
@@ -362,7 +356,7 @@ interface FilePondHookProps {
 interface FilePondMockFileProps {
     source: string,
     options: {
-        type: FilePondOrigin,
+        type: | 'input' | 'limbo' | 'local',
         file?: {
             name?: string,
             size?: number,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,418 @@
+//Type definitions for Filepond <https://github.com/pqina/filepond>
+//Based on definitions by Zach Posten for React-Filepond <https://github.com/zposten>
+//Updated by Hawxy <https://github.com/Hawxy>
+// TypeScript Version: 3.5.2
+
+
+type FilePondOrigin =
+    | 'input' // Added by user
+    | 'limbo' // Temporary server file
+    | 'local' // Existing server file
+    ;
+
+export interface FileProps {
+    src: string;
+    name?: string;
+    size?: number;
+    type?: string;
+    origin?: FilePondOrigin;
+    metadata?: {[key: string]: any};
+}
+
+type ActualFileObject = Blob & {readonly lastModified: number; readonly name: string};
+
+export class File {
+    file: ActualFileObject;
+    fileSize: number;
+    fileType: string;
+    filename: string;
+    fileExtension: string;
+    filenameWithoutExtension: string;
+    id: string;
+    serverId: string;
+    status: number;
+    archived: boolean;
+
+    /** Aborts loading of this file */
+    abortLoad: () => void;
+    /** Aborts processing of this file */
+    abortProcessing: () => void;
+    /**
+     * Retrieve metadata saved to the file, pass a key to retrieve
+     * a specific part of the metadata (e.g. 'crop' or 'resize').
+     * If no key is passed, the entire metadata object is returned.
+     */
+    getMetadata: (key?: string) => any;
+    /** Add additional metadata to the file */
+    setMetadata: (key: string, value: any) => void;
+}
+
+
+interface ServerUrl {
+    url: string;
+    method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+    withCredentials?: boolean;
+    headers?: {[key: string]: string|boolean|number};
+    timeout?: number;
+
+    /**
+     * Called when server response is received, useful for getting
+     * the unique file id from the server response
+     */
+    onload?: () => any;
+    /**
+     * Called when server error is received, receives the response
+     * body, useful to select the relevant error data
+     */
+    onerror?: (responseBody: any) => any;
+    /**
+     * Called with the formdata object right before it is sent,
+     * return extended formdata object to make changes
+     */
+    ondata?: (data: any) => any;
+}
+
+
+type ProgressServerConfigFunction = (
+    /**
+     * Flag indicating if the resource has a length that can be calculated.
+     * If not, the totalDataAmount has no significant value.  Setting this to
+     * false switches the FilePond loading indicator to infinite mode.
+     */
+    isLengthComputable: boolean,
+    /** The amount of data currently transferred */
+    loadedDataAmount: number,
+    /** The total amount of data to be transferred */
+    totalDataAmount: number,
+) => void;
+
+type ProcessServerConfigFunction = (
+    /** The name of the input field */
+    fieldName: string,
+    /** The actual file object to send */
+    file: ActualFileObject,
+    metadata: {[key: string]: any},
+    /**
+     * Should call the load method when done and pass the returned server file id.
+     * This server file id is then used later on when reverting or restoring a file
+     * so that your server knows which file to return without exposing that info
+     * to the client.
+     */
+    load: (p: string | {[key: string]: any}) => void,
+    /** Can call the error method is something went wrong, should exit after */
+    error: (errorText: string) => void,
+    /**
+     * Should call the progress method to update the progress to 100% before calling load()
+     * Setting computable to false switches the loading indicator to infinite mode
+     */
+    progress: ProgressServerConfigFunction,
+    /** Let FilePond know the request has been cancelled */
+    abort: () => void
+) => void;
+
+type RevertServerConfigFunction = (
+    /** Server file id of the file to restore */
+    uniqueFieldId: any,
+    /** Should call the load method when done */
+    load: () => void,
+    /** Can call the error method is something went wrong, should exit after */
+    error: (errorText: string) => void,
+) => void;
+
+type RestoreServerConfigFunction = (
+    uniqueFileId: any,
+    /** Should call the load method with a file object or blob when done */
+    load: (file: ActualFileObject) => void,
+    /** Can call the error method is something went wrong, should exit after */
+    error: (errorText: string) => void,
+    /**
+     * Should call the progress method to update the progress to 100% before calling load()
+     * Setting computable to false switches the loading indicator to infinite mode
+     */
+    progress: ProgressServerConfigFunction,
+    /** Let FilePond know the request has been cancelled */
+    abort: () => void,
+    /*
+     * Can call the headers method to supply FilePond with early response header string
+     * https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders
+     */
+    headers: (headersString: string) => void,
+) => void;
+
+type LoadServerConfigFunction = (
+    source: any,
+    /** Should call the load method with a file object or blob when done */
+    load: (file: ActualFileObject) => void,
+    /** Can call the error method is something went wrong, should exit after */
+    error: (errorText: string) => void,
+    /**
+     * Should call the progress method to update the progress to 100% before calling load()
+     * Setting computable to false switches the loading indicator to infinite mode
+     */
+    progress: ProgressServerConfigFunction,
+    /** Let FilePond know the request has been cancelled */
+    abort: () => void,
+    /*
+     * Can call the headers method to supply FilePond with early response header string
+     * https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders
+     */
+    headers: (headersString: string) => void,
+) => void;
+
+type FetchServerConfigFunction = (
+    url: string,
+    /** Should call the load method with a file object or blob when done */
+    load: (file: ActualFileObject) => void,
+    /** Can call the error method is something went wrong, should exit after */
+    error: (errorText: string) => void,
+    /**
+     * Should call the progress method to update the progress to 100% before calling load()
+     * Setting computable to false switches the loading indicator to infinite mode
+     */
+    progress: ProgressServerConfigFunction,
+    /** Let FilePond know the request has been cancelled */
+    abort: () => void,
+    /*
+     * Can call the headers method to supply FilePond with early response header string
+     * https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders
+     */
+    headers: (headersString: string) => void,
+) => void;
+
+interface FilePondServerConfigProps {
+    instantUpload?: boolean;
+    server?: string | {
+        process?: string | ServerUrl | ProcessServerConfigFunction;
+        revert?: string | ServerUrl | RevertServerConfigFunction;
+        restore?: string | ServerUrl | RestoreServerConfigFunction;
+        load?: string | ServerUrl | LoadServerConfigFunction;
+        fetch?: string | ServerUrl | FetchServerConfigFunction;
+    };
+}
+
+interface FilePondDragDropProps {
+    /** FilePond will catch all files dropped on the webpage */
+    dropOnPage?: boolean;
+    /** Require drop on the FilePond element itself to catch the file. */
+    dropOnElement?: boolean;
+    /**
+     * When enabled, files are validated before they are dropped.
+     * A file is not added when it’s invalid.
+     */
+    dropValidation?: boolean;
+    /**
+     * Ignored file names when handling dropped directories.
+     * Dropping directories is not supported on all browsers.
+     */
+    ignoredFiles?: string[];
+}
+
+interface FilePondLabelProps {
+    /**
+     * The decimal separator used to render numbers.
+     * By default this is determined automatically.
+     */
+    labelDecimalSeparator?: string;
+    /**
+     * The thousands separator used to render numbers.
+     * By default this is determined automatically.
+     */
+    labelThousandsSeparator?: string;
+    /**
+     * Default label shown to indicate this is a drop area.
+     * FilePond will automatically bind browse file events to
+     * the element with CSS class .filepond--label-action
+     */
+    labelIdle?: string;
+    /** Label shown when the field contains invalid files and is validated by the parent form */
+    labelInvalidField?: string;
+    /** Label used while waiting for file size information */
+    labelFileWaitingForSize?: string;
+    /** Label used when no file size information was received */
+    labelFileSizeNotAvailable?: string;
+    /** Label used while loading a file */
+    labelFileLoading?: string;
+    /** Label used when file load failed */
+    labelFileLoadError?: string;
+    /** Label used when uploading a file */
+    labelFileProcessing?: string;
+    /** Label used when file upload has completed */
+    labelFileProcessingComplete?: string;
+    /** Label used when upload was cancelled */
+    labelFileProcessingAborted?: string;
+    /** Label used when something went wrong during file upload */
+    labelFileProcessingError?: string;
+    /** Label used when something went wrong during reverting the file upload */
+    labelFileProcessingRevertError?: string;
+    /** Label used when something went during during removing the file upload */
+    labelFileRemoveError?: string;
+    /** Label used to indicate to the user that an action can be cancelled. */
+    labelTapToCancel?: string;
+    /** Label used to indicate to the user that an action can be retried. */
+    labelTapToRetry?: string;
+    /** Label used to indicate to the user that an action can be undone. */
+    labelTapToUndo?: string;
+    /** Label used for remove button */
+    labelButtonRemoveItem?: string;
+    /** Label used for abort load button */
+    labelButtonAbortItemLoad?: string;
+    /** Label used for retry load button */
+    labelButtonRetryItemLoad?: string;
+    /** Label used for abort upload button */
+    labelButtonAbortItemProcessing?: string;
+    /** Label used for undo upload button */
+    labelButtonUndoItemProcessing?: string;
+    /** Label used for retry upload button */
+    labelButtonRetryItemProcessing?: string;
+    /** Label used for upload button */
+    labelButtonProcessItem?: string;
+}
+
+interface FilePondSvgIconProps {
+    iconRemove?: string;
+    iconProcess?: string;
+    iconRetry?: string;
+    iconUndo?: string;
+}
+
+interface FilePondErrorDescription {
+    main: string;
+    sub: string;
+}
+
+/**
+ * Note that in my testing, callbacks that include an error prop
+ * always give the error as the second prop, with the file as
+ * the first prop.    This is contradictory to the current docs.
+ */
+interface FilePondCallbackProps {
+    /** FilePond instance has been created and is ready. */
+    oninit?: () => void;
+    /**
+     * FilePond instance throws a warning. For instance
+     * when the maximum amount of files has been reached.
+     * Optionally receives file if error is related to a
+     * file object
+     */
+    onwarning?: (error: any, file?: File, status?: any) => void;
+    /**
+     * FilePond instance throws an error. Optionally receives
+     * file if error is related to a file object.
+     */
+    onerror?: (file?: File, error?: FilePondErrorDescription, status?: any) => void;
+    /** Started file load */
+    onaddfilestart?: (file: File) => void;
+    /** Made progress loading a file */
+    onaddfileprogress?: (file: File, progress: number) => void;
+    /** If no error, file has been successfully loaded */
+    onaddfile?: (file: File, error: FilePondErrorDescription) => void;
+    /** Started processing a file */
+    onprocessfilestart?: (file: File) => void;
+    /** Made progress processing a file */
+    onprocessfileprogress?: (file: File, progress: number) => void;
+    /** Aborted processing of a file */
+    onprocessfileabort?: (file: File) => void;
+    /** Processing of a file has been undone */
+    onprocessfileundo?: (file: File) => void;
+    /** If no error, Processing of a file has been completed */
+    onprocessfile?: (file: File, error: FilePondErrorDescription) => void;
+    /** File has been removed. */
+    onremovefile?: (file: File) => void;
+    /**
+     * File has been transformed by the transform plugin or
+     * another plugin subscribing to the prepare_output filter.
+     * It receives the file item and the output data.
+     */
+    onpreparefile?: (file: File, output: any) => void;
+    /** A file has been added or removed, receives a list of file items */
+    onupdatefiles?: (fileItems: File[]) => void;
+}
+
+interface FilePondHookProps {
+    beforeRemoveFile?: (file: File) => boolean;
+}
+
+interface FilePondBaseProps {
+    id?: string;
+    name?: string;
+    disabled?: boolean;
+    /** Class Name to put on wrapper */
+    className?: string;
+    /** Sets the required attribute to the output field */
+    required?: boolean;
+    /** Sets the given value to the capture attribute */
+    captureMethod?: "camera" | "microphone" | "camcorder";
+
+    /** Enable or disable drag n’ drop */
+    allowDrop?: boolean;
+    /** Enable or disable file browser */
+    allowBrowse?: boolean;
+    /**
+     * Enable or disable pasting of files. Pasting files is not
+     * supported on all browsers.
+     */
+    allowPaste?: boolean;
+    /** Enable or disable adding multiple files */
+    allowMultiple?: boolean;
+    /** Allow drop to replace a file, only works when allowMultiple is false */
+    allowReplace?: boolean;
+    /** Allows the user to undo file upload */
+    allowRevert?: boolean;
+    /** Require the file to be reverted before removal */
+    forceRevert?: boolean;
+
+
+    /** The maximum number of files that filepond pond can handle */
+    maxFiles?: number;
+    /** Enables custom validity messages */
+    checkValidity?: boolean;
+
+
+    /** The maximum number of files that can be uploaded in parallel */
+    maxParallelUploads?: number;
+    acceptedFileTypes?: string[];
+    metadata?: {[key: string]: any};
+}
+
+export interface FilePondProps extends
+    FilePondDragDropProps,
+    FilePondServerConfigProps,
+    FilePondLabelProps,
+    FilePondSvgIconProps,
+    FilePondCallbackProps,
+    FilePondHookProps,
+    FilePondBaseProps {}
+
+export class FilePond {
+    setOptions: (options: FilePondProps) => void;
+    addFile: (source: File) => void;
+    addFiles: (source: File[]) => void;
+    removeFile: (query: string) => void;
+    removeFiles: () => void;
+    processFile: (query: string) => void;
+    processFiles: () => void;
+    getFile: () => File;
+    getFiles: () => File[];
+    browse: () => void;
+    context: () => void;
+}
+
+/** Creates a new FilePond instance */
+export function create(element?: any, options?: FilePondProps): void;
+/** Destroys the FilePond instance attached to the supplied element */
+export function destroy(element: any): void;
+/** Returns the FilePond instance attached to the supplied element */
+export function find(element: any): FilePond;
+/**
+ * Parses a given section of the DOM tree for elements with class
+ * .filepond and turns them into FilePond elements.
+ */
+export function parse(context: any): void;
+/** Registers a FilePond plugin for later use */
+export function registerPlugin(...plugins: any[]): void;
+/** Sets page level default options for all FilePond instances */
+export function setOptions(options: FilePondProps): void;
+/** Returns the current default options */
+export function getOptions(): FilePondProps;
+/** Determines whether or not the browser supports FilePond */
+export function supported(): boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -141,7 +141,7 @@ type RestoreServerConfigFunction = (
     progress: ProgressServerConfigFunction,
     /** Let FilePond know the request has been cancelled */
     abort: () => void,
-    /*
+    /**
      * Can call the headers method to supply FilePond with early response header string
      * https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders
      */
@@ -161,9 +161,9 @@ type LoadServerConfigFunction = (
     progress: ProgressServerConfigFunction,
     /** Let FilePond know the request has been cancelled */
     abort: () => void,
-    /*
+    /**
      * Can call the headers method to supply FilePond with early response header string
-     * https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders
+     * https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders>
      */
     headers: (headersString: string) => void,
 ) => void;
@@ -181,7 +181,7 @@ type FetchServerConfigFunction = (
     progress: ProgressServerConfigFunction,
     /** Let FilePond know the request has been cancelled */
     abort: () => void,
-    /*
+    /**
      * Can call the headers method to supply FilePond with early response header string
      * https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders
      */
@@ -290,7 +290,7 @@ interface FilePondSvgIconProps {
     iconUndo?: string;
 }
 
-type FilePondInitialFile = {
+interface FilePondInitialFile {
     source: string;
     options: {
         type: 'input' | 'limbo' | 'local';
@@ -632,8 +632,7 @@ export class FilePond {
     addEventListener: (event: string, fn: (...args: any[]) => void) => void;
     on: (event: string, fn: (...args: any[]) => void) => void;
     onOnce: (event: string, fn: (...args: any[]) => void) => void;
-    off: (event: string, fn: (...args: any[]) => void ) => void;
-    
+    off: (event: string, fn: (...args: any[]) => void) => void;  
 }
 
 /** Creates a new FilePond instance */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -252,7 +252,7 @@ interface FilePondServerConfigProps {
      * See: https://pqina.nl/filepond/docs/patterns/api/filepond-object/#setting-initial-files
      * @default []
      */
-    files?: (FilePondInitialFile | ActualFileObject | Blob | string)[];
+    files?: Array<FilePondInitialFile | ActualFileObject | Blob | string>;
 }
 
 interface FilePondDragDropProps {
@@ -851,7 +851,7 @@ export class FilePond {
      * See: https://pqina.nl/filepond/docs/patterns/api/filepond-object/#setting-initial-files
      * @default []
      */
-    files?: (FilePondInitialFile | ActualFileObject | Blob | string)[];
+    files?: Array<FilePondInitialFile | ActualFileObject | Blob | string>;
 
     /**
      * The decimal separator used to render numbers.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -309,19 +309,21 @@ interface FilePondCallbackProps {
     /** Made progress loading a file */
     onaddfileprogress?: (file: File, progress: number) => void;
     /** If no error, file has been successfully loaded */
-    onaddfile?: (file: File, error: FilePondErrorDescription) => void;
+    onaddfile?: (file: File, error?: FilePondErrorDescription) => void;
     /** Started processing a file */
     onprocessfilestart?: (file: File) => void;
     /** Made progress processing a file */
     onprocessfileprogress?: (file: File, progress: number) => void;
     /** Aborted processing of a file */
     onprocessfileabort?: (file: File) => void;
-    /** Processing of a file has been undone */
-    onprocessfileundo?: (file: File) => void;
+    /** Processing of a file has been reverted */
+    onprocessfilerevert?: (file: File) => void;
     /** If no error, Processing of a file has been completed */
-    onprocessfile?: (file: File, error: FilePondErrorDescription) => void;
+    onprocessfile?: (file: File, error?: FilePondErrorDescription) => void;
+    /** Called when all files in the list have been processed */
+    onprocessfiles?: () => void;
     /** File has been removed. */
-    onremovefile?: (file: File) => void;
+    onremovefile?: (file: File, error?: FilePondErrorDescription) => void;
     /**
      * File has been transformed by the transform plugin or
      * another plugin subscribing to the prepare_output filter.
@@ -330,6 +332,8 @@ interface FilePondCallbackProps {
     onpreparefile?: (file: File, output: any) => void;
     /** A file has been added or removed, receives a list of file items */
     onupdatefiles?: (fileItems: File[]) => void;
+    /* Called when a file is clicked or tapped **/
+    onactivatefile?: (file: File) => void;
 }
 
 interface FilePondHookProps {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,14 +35,14 @@ type ActualFileObject = Blob & {readonly lastModified: number; readonly name: st
 export class File {
     id: string;
     serverId: string;
-    origin: FileOrigin;  
-    status: FileStatus;  
+    origin: FileOrigin;
+    status: FileStatus;
     file: ActualFileObject;
     fileExtension: string;
     fileSize: number;
     fileType: string;
-    filename: string;   
-    filenameWithoutExtension: string; 
+    filename: string;
+    filenameWithoutExtension: string;
 
     /** Aborts loading of this file */
     abortLoad: () => void;
@@ -57,7 +57,6 @@ export class File {
     /** Add additional metadata to the file */
     setMetadata: (key: string, value: any) => void;
 }
-
 
 interface ServerUrl {
     url: string;
@@ -82,7 +81,6 @@ interface ServerUrl {
      */
     ondata?: (data: any) => any;
 }
-
 
 type ProgressServerConfigFunction = (
     /**
@@ -193,6 +191,8 @@ type FetchServerConfigFunction = (
 interface FilePondServerConfigProps {
     instantUpload?: boolean;
     server?: string | {
+        url?: string
+        timeout?: number
         process?: string | ServerUrl | ProcessServerConfigFunction;
         revert?: string | ServerUrl | RevertServerConfigFunction;
         restore?: string | ServerUrl | RestoreServerConfigFunction;
@@ -290,22 +290,22 @@ interface FilePondSvgIconProps {
     iconUndo?: string;
 }
 
-interface FilePondMockFileProps {
-    source: string,
+type FilePondInitialFile = {
+    source: string;
     options: {
-        type: 'input' | 'limbo' | 'local',
+        type: 'input' | 'limbo' | 'local';
         file?: {
-            name?: string,
-            size?: number,
-            type?: string
-        },
+            name?: string;
+            size?: number;
+            type?: string;
+        };
         metadata?: {[key: string]: any};
-    }
+    };
 }
 
 interface FilePondFileProps {
     /** Array of initial files */
-    files?: FilePondMockFileProps[] | ActualFileObject[] | Blob[] | string[];
+    files?: FilePondInitialFile[] | ActualFileObject[] | Blob[] | string[];
 }
 
 interface FilePondErrorDescription {
@@ -392,7 +392,7 @@ interface FilePondBaseProps {
     /** Sets the required attribute to the output field */
     required?: boolean;
     /** Sets the given value to the capture attribute */
-    captureMethod?: CaptureAttribute
+    captureMethod?: CaptureAttribute;
 
     /** Enable or disable drag n’ drop */
     allowDrop?: boolean;
@@ -419,7 +419,7 @@ interface FilePondBaseProps {
 
     itemInsertLocationFreedom?: boolean;
     itemInsertLocation?: 'before' | 'after' | ((a: File, b: File) => number);
-    itemInsertInterval?: number
+    itemInsertInterval?: number;
 
     /** The maximum number of files that can be uploaded in parallel */
     maxParallelUploads?: number;
@@ -456,9 +456,152 @@ export class FilePond {
     maxFiles: number | null;
     maxParallelUploads: number | null;
     checkValidity: boolean;
+
+    itemInsertLocationFreedom: boolean;
     itemInsertLocation: 'before' | 'after' | ((a: File, b: File) => number);
     itemInsertInterval: number;
 
+    dropOnPage: boolean;
+    dropOnElement: boolean;
+    dropValidation: false;
+    ignoredFiles: string[];
+
+    server: string | {
+        url?: string
+        timeout?: number
+        process?: string | ServerUrl | ProcessServerConfigFunction;
+        revert?: string | ServerUrl | RevertServerConfigFunction;
+        restore?: string | ServerUrl | RestoreServerConfigFunction;
+        load?: string | ServerUrl | LoadServerConfigFunction;
+        fetch?: string | ServerUrl | FetchServerConfigFunction;
+    } | null;
+    instantUpload: boolean;
+    files: FilePondInitialFile[] | ActualFileObject[] | Blob[] | string[];
+
+    /**
+     * The decimal separator used to render numbers.
+     * By default this is determined automatically.
+     */
+    labelDecimalSeparator: string;
+    /**
+     * The thousands separator used to render numbers.
+     * By default this is determined automatically.
+     */
+    labelThousandsSeparator: string;
+    /**
+     * Default label shown to indicate this is a drop area.
+     * FilePond will automatically bind browse file events to
+     * the element with CSS class .filepond--label-action
+     */
+    labelIdle: string;
+    /** Label shown when the field contains invalid files and is validated by the parent form */
+    labelInvalidField: string;
+    /** Label used while waiting for file size information */
+    labelFileWaitingForSize: string;
+    /** Label used when no file size information was received */
+    labelFileSizeNotAvailable: string;
+    /** Label used while loading a file */
+    labelFileLoading: string;
+    /** Label used when file load failed */
+    labelFileLoadError: string;
+    /** Label used when uploading a file */
+    labelFileProcessing: string;
+    /** Label used when file upload has completed */
+    labelFileProcessingComplete: string;
+    /** Label used when upload was cancelled */
+    labelFileProcessingAborted: string;
+    /** Label used when something went wrong during file upload */
+    labelFileProcessingError: string;
+    /** Label used when something went wrong during reverting the file upload */
+    labelFileProcessingRevertError: string;
+    /** Label used when something went during during removing the file upload */
+    labelFileRemoveError: string;
+    /** Label used to indicate to the user that an action can be cancelled. */
+    labelTapToCancel: string;
+    /** Label used to indicate to the user that an action can be retried. */
+    labelTapToRetry: string;
+    /** Label used to indicate to the user that an action can be undone. */
+    labelTapToUndo: string;
+    /** Label used for remove button */
+    labelButtonRemoveItem: string;
+    /** Label used for abort load button */
+    labelButtonAbortItemLoad: string;
+    /** Label used for retry load button */
+    labelButtonRetryItemLoad: string;
+    /** Label used for abort upload button */
+    labelButtonAbortItemProcessing: string;
+    /** Label used for undo upload button */
+    labelButtonUndoItemProcessing: string;
+    /** Label used for retry upload button */
+    labelButtonRetryItemProcessing: string;
+    /** Label used for upload button */
+    labelButtonProcessItem: string;
+
+    /** The icon used for remove actions */
+    iconRemove: string;
+    /** The icon used for process actions */
+    iconProcess: string;
+    /** The icon used for retry actions */
+    iconRetry: string;
+    /** The icon used for undo actions */
+    iconUndo: string;
+
+    /** FilePond instance has been created and is ready. */
+    oninit?: () => void;
+    /**
+     * FilePond instance throws a warning. For instance
+     * when the maximum amount of files has been reached.
+     * Optionally receives file if error is related to a
+     * file object
+     */
+    onwarning?: (error: any, file?: File, status?: any) => void;
+    /**
+     * FilePond instance throws an error. Optionally receives
+     * file if error is related to a file object.
+     */
+    onerror?: (file?: File, error?: FilePondErrorDescription, status?: any) => void;
+    /** Started file load */
+    onaddfilestart?: (file: File) => void;
+    /** Made progress loading a file */
+    onaddfileprogress?: (file: File, progress: number) => void;
+    /** If no error, file has been successfully loaded */
+    onaddfile?: (file: File, error?: FilePondErrorDescription) => void;
+    /** Started processing a file */
+    onprocessfilestart?: (file: File) => void;
+    /** Made progress processing a file */
+    onprocessfileprogress?: (file: File, progress: number) => void;
+    /** Aborted processing of a file */
+    onprocessfileabort?: (file: File) => void;
+    /** Processing of a file has been reverted */
+    onprocessfilerevert?: (file: File) => void;
+    /** If no error, Processing of a file has been completed */
+    onprocessfile?: (file: File, error?: FilePondErrorDescription) => void;
+    /** Called when all files in the list have been processed */
+    onprocessfiles?: () => void;
+    /** File has been removed. */
+    onremovefile?: (file: File, error?: FilePondErrorDescription) => void;
+    /**
+     * File has been transformed by the transform plugin or
+     * another plugin subscribing to the prepare_output filter.
+     * It receives the file item and the output data.
+     */
+    onpreparefile?: (file: File, output: any) => void;
+    /** A file has been added or removed, receives a list of file items */
+    onupdatefiles?: (fileItems: File[]) => void;
+    /* Called when a file is clicked or tapped **/
+    onactivatefile?: (file: File) => void;
+
+    beforeDropFile?: (file: File) => boolean;
+    beforeAddFile?: (item: File) => boolean | Promise<boolean>;
+    beforeRemoveFile?: (item: File) => boolean | Promise<boolean>;
+
+    stylePanelLayout: 'integrated' | 'compact' | 'circle';
+    stylePanelAspectRatio: '3:2' | '1';
+    styleItemPanelAspectRatio: string;
+    styleButtonRemoveItemPosition: string;
+    styleButtonProcessItemPosition: string;
+    styleLoadIndicatorPosition: string;
+    styleProgressIndicatorPosition: string;
 
     setOptions: (options: FilePondOptionProps) => void;
     addFile: (source: ActualFileObject | Blob | string, options?: {index: number}) => Promise<File>;
@@ -486,6 +629,11 @@ export class FilePond {
     /** If FilePond replaced the original element, this restores the original element to its original glory */
     restoreElement: (element: Element) => void;
 
+    addEventListener: (event: string, fn: (...args: any[]) => void) => void;
+    on: (event: string, fn: (...args: any[]) => void) => void;
+    onOnce: (event: string, fn: (...args: any[]) => void) => void;
+    off: (event: string, fn: (...args: any[]) => void ) => void;
+    
 }
 
 /** Creates a new FilePond instance */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -435,7 +435,8 @@ interface FilePondErrorDescription {
     sub: string;
 }
 
-interface FilePondCallbackProps {
+/** Exposed for type filtering in downstream packages, please ignore. */
+export interface FilePondCallbackProps {
     /** FilePond instance has been created and is ready. */
     oninit?: () => void;
     /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@
 // Updated by Hawxy <https://github.com/Hawxy>
 // TypeScript Version: 3.5
 
-export {};
+export { };
 
 export enum FileStatus {
     INIT = 1,
@@ -30,7 +30,7 @@ export enum FileOrigin {
     LOCAL = 3
 }
 
-type ActualFileObject = Blob & {readonly lastModified: number; readonly name: string; readonly size: number; readonly type: string};
+type ActualFileObject = Blob & { readonly lastModified: number; readonly name: string; readonly size: number; readonly type: string };
 
 export class File {
     /** Returns the ID of the file. */
@@ -72,7 +72,7 @@ interface ServerUrl {
     url: string;
     method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
     withCredentials?: boolean;
-    headers?: {[key: string]: string|boolean|number};
+    headers?: { [key: string]: string | boolean | number };
     timeout?: number;
 
     /**
@@ -99,9 +99,9 @@ type ProgressServerConfigFunction = (
      * false switches the FilePond loading indicator to infinite mode.
      */
     isLengthComputable: boolean,
-    /** The amount of data currently transferred .*/
+    /** The amount of data currently transferred. */
     loadedDataAmount: number,
-    /** The total amount of data to be transferred.*/
+    /** The total amount of data to be transferred. */
     totalDataAmount: number,
 ) => void;
 
@@ -110,14 +110,14 @@ type ProcessServerConfigFunction = (
     fieldName: string,
     /** The actual file object to send. */
     file: ActualFileObject,
-    metadata: {[key: string]: any},
+    metadata: { [key: string]: any },
     /**
      * Should call the load method when done and pass the returned server file id.
      * This server file id is then used later on when reverting or restoring a file
      * so that your server knows which file to return without exposing that info
      * to the client.
      */
-    load: (p: string | {[key: string]: any}) => void,
+    load: (p: string | { [key: string]: any }) => void,
     /** Can call the error method is something went wrong, should exit after. */
     error: (errorText: string) => void,
     /**
@@ -169,7 +169,7 @@ type LoadServerConfigFunction = (
      * Setting computable to false switches the loading indicator to infinite mode.
      */
     progress: ProgressServerConfigFunction,
-    /** Let FilePond know the request has been cancelled.*/
+    /** Let FilePond know the request has been cancelled. */
     abort: () => void,
     /**
      * Can call the headers method to supply FilePond with early response header string.
@@ -211,12 +211,12 @@ interface FilePondInitialFile {
             type?: string;
         };
         /** File initial metadata. */
-        metadata?: {[key: string]: any};
+        metadata?: { [key: string]: any };
     };
 }
 
 interface FilePondServerConfigProps {
-    /** 
+    /**
      * Server API Configuration.
      * See: https://pqina.nl/filepond/docs/patterns/api/server
      * @default null
@@ -230,7 +230,7 @@ interface FilePondServerConfigProps {
         load?: string | ServerUrl | LoadServerConfigFunction;
         fetch?: string | ServerUrl | FetchServerConfigFunction;
     };
-    /** 
+    /**
      * Immediately upload new files to the server.
      * @default true
      */
@@ -244,14 +244,15 @@ interface FilePondServerConfigProps {
 }
 
 interface FilePondDragDropProps {
-    /** 
+    /**
      * FilePond will catch all files dropped on the webpage.
      * @default false
      */
     dropOnPage?: boolean;
-    /** Require drop on the FilePond element itself to catch the file.
+    /** 
+     * Require drop on the FilePond element itself to catch the file.
      * @default true
-    */
+     */
     dropOnElement?: boolean;
     /**
      * When enabled, files are validated before they are dropped.
@@ -287,107 +288,107 @@ interface FilePondLabelProps {
      * @default 'Drag & Drop your files or <span class="filepond--label-action"> Browse </span>'
      */
     labelIdle?: string;
-    /** 
+    /**
      * Label shown when the field contains invalid files and is validated by the parent form.
      * @default 'Field contains invalid files'
      */
     labelInvalidField?: string;
-    /** 
+    /**
      * Label used while waiting for file size information.
      * @default 'Waiting for size'
      */
     labelFileWaitingForSize?: string;
-    /** 
+    /**
      * Label used when no file size information was received.
      * @default 'Size not available'
      */
     labelFileSizeNotAvailable?: string;
-    /** 
+    /**
      * Label used while loading a file.
      * @default 'Loading'
      */
     labelFileLoading?: string;
-    /** 
+    /**
      * Label used when file load failed.
      * @default 'Error during load'
      */
     labelFileLoadError?: string;
-    /** 
+    /**
      * Label used when uploading a file.
      * @default 'Uploading'
      */
     labelFileProcessing?: string;
-    /** 
+    /**
      * Label used when file upload has completed.
      * @default 'Upload complete'
      */
     labelFileProcessingComplete?: string;
-    /** 
+    /**
      * Label used when upload was cancelled.
      * @default 'Upload cancelled'
      */
     labelFileProcessingAborted?: string;
-    /** 
+    /**
      * Label used when something went wrong during file upload.
      * @default 'Error during upload'
      */
     labelFileProcessingError?: string;
-    /** 
+    /**
      * Label used when something went wrong during reverting the file upload.
      * @default 'Error during revert'
      */
     labelFileProcessingRevertError?: string;
-    /** 
+    /**
      * Label used when something went during during removing the file upload.
      * @default 'Error during remove'
      */
     labelFileRemoveError?: string;
-    /** 
+    /**
      * Label used to indicate to the user that an action can be cancelled.
      * @default 'tap to cancel'
      */
     labelTapToCancel?: string;
-    /** 
+    /**
      * Label used to indicate to the user that an action can be retried.
      * @default 'tap to retry'
      */
     labelTapToRetry?: string;
-    /** 
+    /**
      * Label used to indicate to the user that an action can be undone.
      * @default 'tap to undo'
      */
     labelTapToUndo?: string;
-    /** 
+    /**
      * Label used for remove button.
      * @default 'Remove'
      */
     labelButtonRemoveItem?: string;
-    /** 
+    /**
      * Label used for abort load button.
      * @default 'Abort'
      */
     labelButtonAbortItemLoad?: string;
-    /** 
+    /**
      * Label used for retry load.
      * @default 'Retry'
      */
     labelButtonRetryItemLoad?: string;
-    /** 
+    /**
      * Label used for abort upload button.
      * @default 'Cancel'
      */
     labelButtonAbortItemProcessing?: string;
-    /** 
+    /**
      * Label used for undo upload button.
      * @default 'Undo'
      */
     labelButtonUndoItemProcessing?: string;
-    /** 
+    /**
      * Label used for retry upload button.
      * @default 'Retry'
      */
     labelButtonRetryItemProcessing?: string;
-    /** 
+    /**
      * Label used for upload button.
      * @default 'Upload'
      */
@@ -395,25 +396,25 @@ interface FilePondLabelProps {
 }
 
 interface FilePondSvgIconProps {
-    /** 
+    /**
      * The icon used for remove actions.
      * @default '<svg></svg>'
      */
     iconRemove?: string;
-    /** 
+    /**
      * The icon used for process actions.
      * @default '<svg></svg>'
      */
     iconProcess?: string;
-    /** 
+    /**
      * The icon used for retry actions.
      * @default '<svg></svg>'
      */
     iconRetry?: string;
-     /** 
-      * The icon used for undo actions.
-      * @default '<svg></svg>'
-      */
+    /**
+     * The icon used for undo actions.
+     * @default '<svg></svg>'
+     */
     iconUndo?: string;
 }
 
@@ -549,7 +550,7 @@ interface FilePondBaseProps {
      * The input field name to use.
      * @default 'filepond'
      */
-    name?: string;  
+    name?: string;
     /** 
      * Class Name to put on wrapper.
      * @default null
@@ -650,35 +651,35 @@ export interface FilePondOptionProps extends
     FilePondCallbackProps,
     FilePondHookProps,
     FilePondStyleProps,
-    FilePondBaseProps {}
+    FilePondBaseProps { }
 
-type FilePondEventPrefixed = 'FilePond:init' 
-| 'FilePond:warning' 
-| 'FilePond:error' 
-| 'FilePond:addfilestart' 
-| 'FilePond:addfileprogress' 
-| 'FilePond:addfile'
-| 'FilePond:processfilestart' 
-| 'FilePond:processfileprogress' 
-| 'FilePond:processfileabort' 
-| 'FilePond:processfilerevert' 
-| 'FilePond:processfile' 
-| 'FilePond:removefile' 
-| 'FilePond:updatefiles'
+type FilePondEventPrefixed = 'FilePond:init'
+    | 'FilePond:warning'
+    | 'FilePond:error'
+    | 'FilePond:addfilestart'
+    | 'FilePond:addfileprogress'
+    | 'FilePond:addfile'
+    | 'FilePond:processfilestart'
+    | 'FilePond:processfileprogress'
+    | 'FilePond:processfileabort'
+    | 'FilePond:processfilerevert'
+    | 'FilePond:processfile'
+    | 'FilePond:removefile'
+    | 'FilePond:updatefiles';
 
-type FilePondEvent = 'init' 
-| 'warning' 
-| 'error' 
-| 'addfilestart' 
-| 'addfileprogress' 
-| 'addfile' 
-| 'processfilestart' 
-| 'processfileprogress' 
-| 'processfileabort'
-| 'processfilerevert'
-| 'processfile'
-| 'removefile'
-| 'updatefiles'
+type FilePondEvent = 'init'
+    | 'warning'
+    | 'error'
+    | 'addfilestart'
+    | 'addfileprogress'
+    | 'addfile'
+    | 'processfilestart'
+    | 'processfileprogress'
+    | 'processfileabort'
+    | 'processfilerevert'
+    | 'processfile'
+    | 'removefile'
+    | 'updatefiles';
 
 export class FilePond {
     /**
@@ -700,7 +701,7 @@ export class FilePond {
      * The input field name to use.
      * @default 'filepond'
      */
-    name: string;  
+    name: string;
     /** 
      * Class Name to put on wrapper.
      * @default null
@@ -790,16 +791,17 @@ export class FilePond {
      * The maximum number of files that can be uploaded in parallel.
      * @default null
      */
-    maxParallelUploads: number | null;   
+    maxParallelUploads: number | null;
 
     /** 
      * FilePond will catch all files dropped on the webpage.
      * @default false
      */
     dropOnPage: boolean;
-    /** Require drop on the FilePond element itself to catch the file.
+    /** 
+     * Require drop on the FilePond element itself to catch the file.
      * @default true
-    */
+     */
     dropOnElement: boolean;
     /**
      * When enabled, files are validated before they are dropped.
@@ -982,10 +984,10 @@ export class FilePond {
      * @default '<svg></svg>'
      */
     iconRetry: string;
-     /** 
-      * The icon used for undo actions.
-      * @default '<svg></svg>'
-      */
+    /** 
+     * The icon used for undo actions.
+     * @default '<svg></svg>'
+     */
     iconUndo: string;
 
     /** FilePond instance has been created and is ready. */
@@ -1098,12 +1100,12 @@ export class FilePond {
      * Adds a file.
      * @param options.index The index that the file should be added at.
      */
-    addFile: (source: ActualFileObject | Blob | string, options?: {index: number}) => Promise<File>;
+    addFile: (source: ActualFileObject | Blob | string, options?: { index: number }) => Promise<File>;
     /** 
      * Adds multiple files.
      * @param options.index The index that the files should be added at.
      */
-    addFiles: (source: ActualFileObject[] | Blob[] | string[], options?: {index: number}) => Promise<File[]>;
+    addFiles: (source: ActualFileObject[] | Blob[] | string[], options?: { index: number }) => Promise<File[]>;
     /** 
      * Removes a file. If no parameter is provided, removes the first file in the list.
      * @param query The file reference, id, or index.
@@ -1167,18 +1169,18 @@ export class FilePond {
      * @param fn Event handler, signature is identical to the callback method
      */
     on: (event: FilePondEvent, fn: (...args: any[]) => void) => void;
-     /** 
+    /** 
      * Listen to an event once and remove the handler.
      * @param event Name of the event
      * @param fn Event handler, signature is identical to the callback method
      */
     onOnce: (event: FilePondEvent, fn: (...args: any[]) => void) => void;
-     /** 
+    /** 
      * Stop listening to an event.
      * @param event Name of the event
      * @param fn Event handler, signature is identical to the callback method
      */
-    off: (event: FilePondEvent, fn: (...args: any[]) => void) => void;  
+    off: (event: FilePondEvent, fn: (...args: any[]) => void) => void;
 }
 
 /** Creates a new FilePond instance. */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -234,6 +234,7 @@ interface FilePondServerConfigProps {
     server?: string | {
         url?: string
         timeout?: number
+        headers?: { [key: string]: string | boolean | number };
         process?: string | ServerUrl | ProcessServerConfigFunction | null;
         revert?: string | ServerUrl | RevertServerConfigFunction | null;
         restore?: string | ServerUrl | RestoreServerConfigFunction | null;
@@ -836,12 +837,13 @@ export class FilePond {
     server?: string | {
         url?: string
         timeout?: number
+        headers?: { [key: string]: string | boolean | number } | null;
         process?: string | ServerUrl | ProcessServerConfigFunction | null;
         revert?: string | ServerUrl | RevertServerConfigFunction | null;
         restore?: string | ServerUrl | RestoreServerConfigFunction | null;
         load?: string | ServerUrl | LoadServerConfigFunction | null;
         fetch?: string | ServerUrl | FetchServerConfigFunction | null;
-        remove: RemoveServerConfigFunction | null;
+        remove?: RemoveServerConfigFunction | null;
     } | null;
 
     /** 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -79,12 +79,12 @@ interface ServerUrl {
      * Called when server response is received, useful for getting
      * the unique file id from the server response.
      */
-    onload?: (response: any) => void;
+    onload?: (response: any) => number | string;
     /**
      * Called when server error is received, receives the response
      * body, useful to select the relevant error data.
      */
-    onerror?: (responseBody: any) => void;
+    onerror?: (responseBody: any) => any;
     /**
      * Called with the formdata object right before it is sent,
      * return extended formdata object to make changes.
@@ -252,7 +252,7 @@ interface FilePondServerConfigProps {
      * See: https://pqina.nl/filepond/docs/patterns/api/filepond-object/#setting-initial-files
      * @default []
      */
-    files?: FilePondInitialFile[] | ActualFileObject[] | Blob[] | string[];
+    files?: (FilePondInitialFile | ActualFileObject | Blob | string)[];
 }
 
 interface FilePondDragDropProps {
@@ -435,11 +435,6 @@ interface FilePondErrorDescription {
     sub: string;
 }
 
-/**
- * Note that in my testing, callbacks that include an error prop
- * always give the error as the second prop, with the file as
- * the first prop.    This is contradictory to the current docs.
- */
 interface FilePondCallbackProps {
     /** FilePond instance has been created and is ready. */
     oninit?: () => void;
@@ -454,13 +449,13 @@ interface FilePondCallbackProps {
      * FilePond instance throws an error. Optionally receives
      * file if error is related to a file object.
      */
-    onerror?: (file?: File, error?: FilePondErrorDescription, status?: any) => void;
+    onerror?: (error: FilePondErrorDescription, file?: File, status?: any) => void;
     /** Started file load. */
     onaddfilestart?: (file: File) => void;
     /** Made progress loading a file. */
     onaddfileprogress?: (file: File, progress: number) => void;
     /** If no error, file has been successfully loaded. */
-    onaddfile?: (file: File, error?: FilePondErrorDescription) => void;
+    onaddfile?: (error: FilePondErrorDescription | null, file: File) => void;
     /** Started processing a file. */
     onprocessfilestart?: (file: File) => void;
     /** Made progress processing a file. */
@@ -470,11 +465,11 @@ interface FilePondCallbackProps {
     /** Processing of a file has been reverted. */
     onprocessfilerevert?: (file: File) => void;
     /** If no error, Processing of a file has been completed. */
-    onprocessfile?: (file: File, error?: FilePondErrorDescription) => void;
+    onprocessfile?: (error: FilePondErrorDescription | null, file: File) => void;
     /** Called when all files in the list have been processed. */
     onprocessfiles?: () => void;
     /** File has been removed. */
-    onremovefile?: (file: File, error?: FilePondErrorDescription) => void;
+    onremovefile?: (error: FilePondErrorDescription | null, file: File) => void;
     /**
      * File has been transformed by the transform plugin or
      * another plugin subscribing to the prepare_output filter.
@@ -482,7 +477,7 @@ interface FilePondCallbackProps {
      */
     onpreparefile?: (file: File, output: any) => void;
     /** A file has been added or removed, receives a list of file items. */
-    onupdatefiles?: (fileItems: File[]) => void;
+    onupdatefiles?: (files: File[]) => void;
     /* Called when a file is clicked or tapped. **/
     onactivatefile?: (file: File) => void;
 }
@@ -856,7 +851,7 @@ export class FilePond {
      * See: https://pqina.nl/filepond/docs/patterns/api/filepond-object/#setting-initial-files
      * @default []
      */
-    files?: FilePondInitialFile[] | ActualFileObject[] | Blob[] | string[];
+    files?: (FilePondInitialFile | ActualFileObject | Blob | string)[];
 
     /**
      * The decimal separator used to render numbers.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -290,6 +290,24 @@ interface FilePondSvgIconProps {
     iconUndo?: string;
 }
 
+interface FilePondMockFileProps {
+    source: string,
+    options: {
+        type: 'input' | 'limbo' | 'local',
+        file?: {
+            name?: string,
+            size?: number,
+            type?: string
+        },
+        metadata?: {[key: string]: any};
+    }
+}
+
+interface FilePondFileProps {
+    /** Array of initial files */
+    files?: FilePondMockFileProps[] | ActualFileObject[] | Blob[] | string[];
+}
+
 interface FilePondErrorDescription {
     main: string;
     sub: string;
@@ -353,22 +371,14 @@ interface FilePondHookProps {
     beforeRemoveFile?: (item: File) => boolean | Promise<boolean>;
 }
 
-interface FilePondMockFileProps {
-    source: string,
-    options: {
-        type: | 'input' | 'limbo' | 'local',
-        file?: {
-            name?: string,
-            size?: number,
-            type?: string
-        },
-        metadata?: {[key: string]: any};
-    }
-}
-
-interface FilePondFileProps {
-    /** Array of initial files */
-    files?: FilePondMockFileProps[]
+interface FilePondStyleProps {
+    stylePanelLayout?: 'integrated' | 'compact' | 'circle';
+    stylePanelAspectRatio?: '3:2' | '1';
+    styleItemPanelAspectRatio?: string;
+    styleButtonRemoveItemPosition?: string;
+    styleButtonProcessItemPosition?: string;
+    styleLoadIndicatorPosition?: string;
+    styleProgressIndicatorPosition?: string;
 }
 
 type CaptureAttribute = "camera" | "microphone" | "camcorder";
@@ -423,18 +433,19 @@ export interface FilePondOptionProps extends
     FilePondSvgIconProps,
     FilePondCallbackProps,
     FilePondHookProps,
+    FilePondStyleProps,
     FilePondFileProps,
     FilePondBaseProps {}
 
 export class FilePond {
-    readonly element: Element | undefined;
+    readonly element: Element | null;
     readonly status: Status;
 
     name: string;
-    className: string | undefined;
+    className: string | null;
     required: boolean;
     disabled: boolean;
-    captureMethod: CaptureAttribute | undefined;
+    captureMethod: CaptureAttribute | null;
     allowDrop: boolean;
     allowBrowse: boolean;
     allowPaste: boolean;
@@ -442,19 +453,19 @@ export class FilePond {
     allowReplace: boolean;
     allowRevert: boolean;
     forceRevert: boolean;
-    maxFiles: number | undefined;
-    maxParallelUploads: number | undefined;
+    maxFiles: number | null;
+    maxParallelUploads: number | null;
     checkValidity: boolean;
     itemInsertLocation: 'before' | 'after' | ((a: File, b: File) => number);
     itemInsertInterval: number;
 
 
     setOptions: (options: FilePondOptionProps) => void;
-    addFile: (source: ActualFileObject | Blob | string, options?: {index: number}) => Promise<File[]>;
+    addFile: (source: ActualFileObject | Blob | string, options?: {index: number}) => Promise<File>;
     addFiles: (source: ActualFileObject[] | Blob[] | string[], options?: {index: number}) => Promise<File[]>;
-    removeFile: (query?: string | number) => void;
+    removeFile: (query?: File | string | number) => void;
     removeFiles: () => void;
-    processFile: (query?: string | number) => Promise<File>;
+    processFile: (query?: File | string | number) => Promise<File>;
     processFiles: () => Promise<File[]>;
     getFile: () => File;
     getFiles: () => File[];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -471,18 +471,65 @@ interface FilePondCallbackProps {
 }
 
 interface FilePondHookProps {
-    beforeDropFile?: (file: File) => boolean;
+    /**
+     * FilePond is about to allow this item to be dropped, it can be a URL or a File object.
+     * 
+     * Return `true` or `false` depending on if you want to allow the item to be dropped.
+     */
+    beforeDropFile?: (file: File | string) => boolean;
+    /**
+     * FilePond is about to add this file. 
+     * 
+     * Return `false` to prevent adding it, or return a `Promise` and resolve with `true` or `false`.
+     */
     beforeAddFile?: (item: File) => boolean | Promise<boolean>;
+    /**
+     * FilePond is about to remove this file. 
+     * 
+     * Return `false` to prevent adding it, or return a `Promise` and resolve with `true` or `false`.
+     */
     beforeRemoveFile?: (item: File) => boolean | Promise<boolean>;
 }
 
 interface FilePondStyleProps {
+    /** 
+     * Set a different layout render mode.
+     * @default null
+     */
     stylePanelLayout?: 'integrated' | 'compact' | 'circle';
-    stylePanelAspectRatio?: '3:2' | '1';
+    /**
+     * Set a forced aspect ratio for the FilePond drop area.
+     * 
+     * Accepts human readable aspect ratios like `1:1` or numeric aspect ratios like `0.75`.
+     * @default null
+     */
+    stylePanelAspectRatio?: string;
+    /**
+     * Set a forced aspect ratio for the file items. 
+     * 
+     * Useful when rendering cropped or fixed aspect ratio images in grid view.
+     * @default null
+     */
     styleItemPanelAspectRatio?: string;
+    /** 
+     * The position of the remove item button
+     * @default 'left'
+     */
     styleButtonRemoveItemPosition?: string;
+    /**
+     * The position of the remove item button.
+     * @default 'right' 
+     */
     styleButtonProcessItemPosition?: string;
+    /**
+     * The position of the load indicator
+     * @default 'right'
+     */
     styleLoadIndicatorPosition?: string;
+    /**
+     * The position of the progress indicator
+     * @default 'right'
+     */
     styleProgressIndicatorPosition?: string;
 }
 

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -50,23 +50,30 @@ pond.itemInsertLocation = (a, b) => {
   return 0;
 }
 
+pond.addEventListener('FilePond:addfile', e => {
+  console.log(e.detail);
+})
+
 const data = { hello: 'world' };
 const blob = new Blob([JSON.stringify(data, null, 2)], {
     type: 'application/json'
 });
-
 pond.addFile(blob);
+
 const file = new File(["aaaa"], "something")
-if(file) {
-  pond.addFile(file);
-}
-
+pond.addFile(file);
 pond.addFile('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==')
-
 pond.addFile('./my-file.jpg').then(file => {
   pond.removeFile(file);
 });
 
+pond.on('addfile', (error, file) => {
+  if (error) {
+      console.log('Oh no');
+      return;
+  }
+  console.log('File added', file);
+});
 
 // $ExpectType Status
 let status = pond.status

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -15,6 +15,49 @@ const pond = FilePond.create(undefined, {
       return {
         abort: () => {abort();}
       }
+    },
+    revert: (uniqueFileId, load, error) => { 
+      error('oh my goodness');    
+      load();
+    },
+    load: (source, load, error, progress, abort, headers) => {
+      error('oh my goodness');
+      headers("headersString");
+      progress(true, 0, 1024);
+      load(new File(["aaaa"], "something"));
+      return {
+        abort: () => {        
+          abort();
+        }
+      };
+    },
+    fetch: (url, load, error, progress, abort, headers) => { 
+      error('oh my goodness');     
+      headers("");    
+      progress(true, 0, 1024);
+      load(new File(["aaaa"], "something"));     
+      return {
+          abort: () => {           
+            abort();
+          }
+      };
+    },
+    restore: (uniqueFileId, load, error, progress, abort, headers) => { 
+      error('oh my goodness');    
+      headers("");    
+      progress(true, 0, 1024);    
+      load(new File(["aaaa"], "something"));
+     
+      return {
+          abort: () => {
+
+              abort();
+          }
+      };
+    },
+    remove: (source, load, error) => { 
+      error('oh my goodness');
+      load();
     }
   },
   itemInsertLocation: (a, b) => {
@@ -50,6 +93,8 @@ pond.itemInsertLocation = (a, b) => {
   return 0;
 }
 
+
+
 FilePond.setOptions({
   allowDrop: false,
   allowReplace: false,
@@ -84,7 +129,16 @@ FilePond.setOptions({
       revert: './revert',
       restore: './restore/',
       load: './load/',
-      fetch: './fetch/'
+      fetch: './fetch/',
+      remove: null
+  }
+});
+
+FilePond.setOptions({
+  server: {
+      process: './process',
+      fetch: null,
+      revert: null
   }
 });
 
@@ -112,13 +166,3 @@ pond.on('addfile', (error, file) => {
   }
   console.log('File added', file);
 });
-
-// $ExpectType Status
-let status = pond.status
-
-
-
-
-
-
-

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -50,6 +50,44 @@ pond.itemInsertLocation = (a, b) => {
   return 0;
 }
 
+FilePond.setOptions({
+  allowDrop: false,
+  allowReplace: false,
+  instantUpload: false,
+  server: {
+      url: 'http://192.168.33.10',
+      process: './process.php',
+      revert: './revert.php',
+      restore: './restore.php?id=',
+      fetch: './fetch.php?data='
+  }
+});
+
+FilePond.setOptions({
+  server: {
+      url: 'http://192.168.0.100',
+      timeout: 7000,
+      process: {
+          url: './process',
+          method: 'POST',
+          headers: {
+              'x-customheader': 'Hello World'
+          },
+          withCredentials: false,
+          onload: (response) => response.key,
+          onerror: (response) => response.data,
+          ondata: (formData) => {
+              formData.append('Hello', 'World');
+              return formData;
+          }
+      },
+      revert: './revert',
+      restore: './restore/',
+      load: './load/',
+      fetch: './fetch/'
+  }
+});
+
 pond.addEventListener('FilePond:addfile', e => {
   console.log(e.detail);
 })

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -55,16 +55,17 @@ const blob = new Blob([JSON.stringify(data, null, 2)], {
     type: 'application/json'
 });
 
-pond.addFile(blob)
-
-const fl = new FileList();
-const file = fl.item(0);
+pond.addFile(blob);
+const file = new File(["aaaa"], "something")
 if(file) {
   pond.addFile(file);
 }
 
-
 pond.addFile('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==')
+
+pond.addFile('./my-file.jpg').then(file => {
+  pond.removeFile(file);
+});
 
 
 // $ExpectType Status

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -1,7 +1,7 @@
 import * as FilePond from 'filepond';
 
 const pond1 = FilePond.create();
-const pond2 = FilePond.create('eeee')
+const pond2 = FilePond.create('<div></div>')
 const pond = FilePond.create(undefined, {
   name: "",
   files: [{
@@ -9,8 +9,16 @@ const pond = FilePond.create(undefined, {
     options: {
       type: "limbo"
     }
-  }]
+  }],
+  server: {
+    process: (fieldName, file, metadata, load, error, progress, abort) => {
+      return {
+        abort: () => {abort();}
+      }
+    }
+  } 
 })
+pond.isAttachedTo(new Element())
 
 
 

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -1,6 +1,17 @@
 import * as FilePond from 'filepond';
 
+const pond1 = FilePond.create();
+const pond2 = FilePond.create('eeee')
 const pond = FilePond.create(undefined, {
-  name: ""
-
+  name: "",
+  files: [{
+    source: "123",
+    options: {
+      type: "limbo"
+    }
+  }]
 })
+
+
+
+

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -1,0 +1,6 @@
+import * as FilePond from 'filepond';
+
+const pond = FilePond.create(undefined, {
+  name: ""
+
+})

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -1,13 +1,13 @@
 import * as FilePond from 'filepond';
 
 const pond1 = FilePond.create();
-const pond2 = FilePond.create('<div></div>')
+const pond2 = FilePond.create(new Element())
 const pond = FilePond.create(undefined, {
   name: "",
   files: [{
     source: "123",
     options: {
-      type: "limbo"
+      type: 'limbo'
     }
   }],
   server: {
@@ -16,9 +16,62 @@ const pond = FilePond.create(undefined, {
         abort: () => {abort();}
       }
     }
-  } 
+  },
+  itemInsertLocation: (a, b) => {
+
+    // If no file data yet, treat as equal
+    if (!(a.file && b.file)) return 0;
+    
+    // Move to right location in list
+    if (a.fileSize < b.fileSize) {
+        return -1;
+    }
+    else if (b.fileSize > a.fileSize) {
+        return 1;
+    }
+
+    return 0;
+}
 })
-pond.isAttachedTo(new Element())
+
+pond.itemInsertLocation = (a, b) => {
+
+  // If no file data yet, treat as equal
+  if (!(a.file && b.file)) return 0;
+  
+  // Move to right location in list
+  if (a.fileSize < b.fileSize) {
+      return -1;
+  }
+  else if (b.fileSize > a.fileSize) {
+      return 1;
+  }
+
+  return 0;
+}
+
+const data = { hello: 'world' };
+const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: 'application/json'
+});
+
+pond.addFile(blob)
+
+const fl = new FileList();
+const file = fl.item(0);
+if(file) {
+  pond.addFile(file);
+}
+
+
+pond.addFile('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==')
+
+
+// $ExpectType Status
+let status = pond.status
+
+
+
 
 
 

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -1,5 +1,10 @@
 import * as FilePond from 'filepond';
 
+const data = { hello: 'world' };
+const blob = new Blob([JSON.stringify(data, null, 2)], {
+  type: 'application/json'
+});
+const file = new File(["aaaa"], "something")
 const pond1 = FilePond.create();
 const pond2 = FilePond.create(new Element())
 const pond = FilePond.create(undefined, {
@@ -9,15 +14,18 @@ const pond = FilePond.create(undefined, {
     options: {
       type: 'limbo'
     }
-  }],
+  },
+    "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==",
+    file,
+    blob],
   server: {
     process: (fieldName, file, metadata, load, error, progress, abort) => {
       return {
-        abort: () => {abort();}
+        abort: () => { abort(); }
       }
     },
-    revert: (uniqueFileId, load, error) => { 
-      error('oh my goodness');    
+    revert: (uniqueFileId, load, error) => {
+      error('oh my goodness');
       load();
     },
     load: (source, load, error, progress, abort, headers) => {
@@ -26,36 +34,36 @@ const pond = FilePond.create(undefined, {
       progress(true, 0, 1024);
       load(new File(["aaaa"], "something"));
       return {
-        abort: () => {        
+        abort: () => {
           abort();
         }
       };
     },
-    fetch: (url, load, error, progress, abort, headers) => { 
-      error('oh my goodness');     
-      headers("");    
+    fetch: (url, load, error, progress, abort, headers) => {
+      error('oh my goodness');
+      headers("");
       progress(true, 0, 1024);
-      load(new File(["aaaa"], "something"));     
-      return {
-          abort: () => {           
-            abort();
-          }
-      };
-    },
-    restore: (uniqueFileId, load, error, progress, abort, headers) => { 
-      error('oh my goodness');    
-      headers("");    
-      progress(true, 0, 1024);    
       load(new File(["aaaa"], "something"));
-     
       return {
-          abort: () => {
-
-              abort();
-          }
+        abort: () => {
+          abort();
+        }
       };
     },
-    remove: (source, load, error) => { 
+    restore: (uniqueFileId, load, error, progress, abort, headers) => {
+      error('oh my goodness');
+      headers("");
+      progress(true, 0, 1024);
+      load(new File(["aaaa"], "something"));
+
+      return {
+        abort: () => {
+
+          abort();
+        }
+      };
+    },
+    remove: (source, load, error) => {
       error('oh my goodness');
       load();
     }
@@ -64,30 +72,30 @@ const pond = FilePond.create(undefined, {
 
     // If no file data yet, treat as equal
     if (!(a.file && b.file)) return 0;
-    
+
     // Move to right location in list
     if (a.fileSize < b.fileSize) {
-        return -1;
+      return -1;
     }
     else if (b.fileSize > a.fileSize) {
-        return 1;
+      return 1;
     }
 
     return 0;
-}
+  }
 })
 
 pond.itemInsertLocation = (a, b) => {
 
   // If no file data yet, treat as equal
   if (!(a.file && b.file)) return 0;
-  
+
   // Move to right location in list
   if (a.fileSize < b.fileSize) {
-      return -1;
+    return -1;
   }
   else if (b.fileSize > a.fileSize) {
-      return 1;
+    return 1;
   }
 
   return 0;
@@ -100,57 +108,57 @@ FilePond.setOptions({
   allowReplace: false,
   instantUpload: false,
   server: {
-      url: 'http://192.168.33.10',
-      process: './process.php',
-      revert: './revert.php',
-      restore: './restore.php?id=',
-      fetch: './fetch.php?data='
+    url: 'http://192.168.33.10',
+    process: './process.php',
+    revert: './revert.php',
+    restore: './restore.php?id=',
+    fetch: './fetch.php?data='
   }
 });
 
 FilePond.setOptions({
   server: {
-      url: 'http://192.168.0.100',
-      timeout: 7000,
-      process: {
-          url: './process',
-          method: 'POST',
-          headers: {
-              'x-customheader': 'Hello World'
-          },
-          withCredentials: false,
-          onload: (response) => response.key,
-          onerror: (response) => response.data,
-          ondata: (formData) => {
-              formData.append('Hello', 'World');
-              return formData;
-          }
+    url: 'http://192.168.0.100',
+    timeout: 7000,
+    process: {
+      url: './process',
+      method: 'POST',
+      headers: {
+        'x-customheader': 'Hello World'
       },
-      revert: './revert',
-      restore: './restore/',
-      load: './load/',
-      fetch: './fetch/',
-      remove: null
+      withCredentials: false,
+      onload: (response) => response.key,
+      onerror: (response) => response.data,
+      ondata: (formData) => {
+        formData.append('Hello', 'World');
+        return formData;
+      }
+    },
+    revert: './revert',
+    restore: './restore/',
+    load: './load/',
+    fetch: './fetch/',
+    remove: null
   }
 });
 
 FilePond.setOptions({
   server: {
-      process: './process',
-      fetch: null,
-      revert: null
+    process: './process',
+    fetch: null,
+    revert: null
   }
 });
 
 pond.server = {
   headers: {
-      foo: 'bar'
+    foo: 'bar'
   },
   revert: {
-      url: "",
-      headers: {
-          foo: 'baz'
-      }
+    url: "",
+    headers: {
+      foo: 'baz'
+    }
   }
 }
 
@@ -158,13 +166,18 @@ pond.addEventListener('FilePond:addfile', e => {
   console.log(e.detail);
 })
 
-const data = { hello: 'world' };
-const blob = new Blob([JSON.stringify(data, null, 2)], {
-    type: 'application/json'
-});
-pond.addFile(blob);
 
-const file = new File(["aaaa"], "something")
+pond.files = [{
+  source: "123",
+  options: {
+    type: 'limbo'
+  }
+},
+  "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==",
+  file,
+  blob]
+
+pond.addFile(blob);
 pond.addFile(file);
 pond.addFile('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==')
 pond.addFile('./my-file.jpg').then(file => {
@@ -173,8 +186,8 @@ pond.addFile('./my-file.jpg').then(file => {
 
 pond.on('addfile', (error, file) => {
   if (error) {
-      console.log('Oh no');
-      return;
+    console.log('Oh no');
+    return;
   }
   console.log('File added', file);
 });

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -142,6 +142,18 @@ FilePond.setOptions({
   }
 });
 
+pond.server = {
+  headers: {
+      foo: 'bar'
+  },
+  revert: {
+      url: "",
+      headers: {
+          foo: 'baz'
+      }
+  }
+}
+
 pond.addEventListener('FilePond:addfile', e => {
   console.log(e.detail);
 })

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "esnext",
+        "module": "commonjs",
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
@@ -12,8 +12,5 @@
         // If the library is global (cannot be imported via `import` or `require`), leave this out.
         "baseUrl": ".",
         "paths": { "filepond": ["."] }
-    },
-    "include": [
-        "**/*.d.ts"
-    ]
+    }   
 }

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "dom"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "noEmit": true,
+
+        // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
+        // If the library is global (cannot be imported via `import` or `require`), leave this out.
+        "baseUrl": ".",
+        "paths": { "filepond": ["."] }
+    }
+}

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "esnext",
         "lib": ["es6", "dom"],
         "noImplicitAny": true,
         "noImplicitThis": true,
@@ -12,5 +12,8 @@
         // If the library is global (cannot be imported via `import` or `require`), leave this out.
         "baseUrl": ".",
         "paths": { "filepond": ["."] }
-    }
+    },
+    "include": [
+        "**/*.d.ts"
+    ]
 }


### PR DESCRIPTION
Opening for some early feedback. Thanks to @zposten for his previous work on the react-filepond types, it covered about 50% of the current API surface and saved me a bunch of time. I left most of his docs in the new definitions for the time being.

TODO:
- [x] Some kind of proper test file
- [x] Finish updating docs (and mention default values)

Current questions:

1. Can the initial files array contain multiple different types of files (blob + mocked etc) or just multiple of a specific type?
2. Verification that the callback props are correct would be nice. Per the comment left by zposten, I have a feeling that some of them are incorrect or in the wrong order.

Fixes: #159 