### PR TITLE
Add check for state.request.abort

### DIFF
--- a/src/js/app/utils/createFileProcessor.js
+++ b/src/js/app/utils/createFileProcessor.js
@@ -156,7 +156,9 @@ export const createFileProcessor = processFn => {
         state.perceivedPerformanceUpdater.clear();
 
         // abort actual request
-        state.request.abort();
+        if (state.request.abort) {
+            state.request.abort();
+        }
 
         // if has response object, we've completed the request
         state.complete = true;


### PR DESCRIPTION
This seems to be a similar fix to https://github.com/pqina/filepond/pull/341

abort function does not exist when using ProcessServerConfigFunction in a React app