### PR TITLE
types: fix error object

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -451,8 +451,9 @@ interface FilePondSvgIconProps {
 }
 
 interface FilePondErrorDescription {
-    main: string;
-    sub: string;
+    type: string;
+    code: number;
+    body: string;
 }
 
 /** Exposed for type filtering in downstream packages, please ignore. */


### PR DESCRIPTION
From my experience, the error object looks like this 
```javascript
{type: "error", code: 0, body: "Network Error"}
```