### PR TITLE
types: origin as FileOrigin instead of a string

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -38,7 +38,7 @@ export class File {
     /** Returns the server id of the file. */
     serverId: string;
     /** Returns the origin of the file. */
-    origin: 'input' | 'limbo' | 'local';
+    origin: FileOrigin;
     /** Returns the current status of the file. */
     status: FileStatus;
     /** Returns the File object. */
@@ -213,7 +213,7 @@ interface FilePondInitialFile {
     source: string;
     options: {
         /** Origin of file being added. */
-        type: 'input' | 'limbo' | 'local';
+        type: FileOrigin;
         /** Mock file information. */
         file?: {
             name?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -213,7 +213,7 @@ interface FilePondInitialFile {
     source: string;
     options: {
         /** Origin of file being added. */
-        type: FileOrigin;
+        type: 'input' | 'limbo' | 'local';
         /** Mock file information. */
         file?: {
             name?: string;


### PR DESCRIPTION
![Capture](https://user-images.githubusercontent.com/1556750/73550054-2f490180-4444-11ea-9d20-bf104ab34cc4.PNG)

When I'm in `processfile`, the `origin` property of the `File` object is a number.

I'm using the `FileOrigin` enum to avoid a clash of types in this function because the current definition has the following type `'input' | 'limbo' | 'local'`.