### PR TITLE
types: add source property to File

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,13 +30,15 @@ export enum FileOrigin {
     LOCAL = 3
 }
 
-type ActualFileObject = Blob & { readonly lastModified: number; readonly name: string; readonly size: number; readonly type: string };
+type ActualFileObject = Blob & { readonly lastModified: number; readonly name: string; };
 
 export class File {
     /** Returns the ID of the file. */
     id: string;
     /** Returns the server id of the file. */
     serverId: string;
+    /** Returns the source of the file. */
+    source: ActualFileObject | string;
     /** Returns the origin of the file. */
     origin: 'input' | 'limbo' | 'local';
     /** Returns the current status of the file. */


### PR DESCRIPTION
`File` has a source property which can be a string or an ActualFileObject.

I removed the `size` and `type` of `ActualFileObject` properties because they are already present in the `Blob` type.

The `File` type should be renamed to `FilePondFile` and `ActualFileObject` replaced with the native `File` type. 