### PR TITLE
Allow custom response text on error

### DIFF
--- a/src/js/app/utils/createFileProcessorFunction.js
+++ b/src/js/app/utils/createFileProcessorFunction.js
@@ -59,7 +59,7 @@ export const createFileProcessorFunction = (apiUrl, action, name, options) => (f
             createResponse(
                 'error',
                 xhr.status,
-                onerror(xhr.response) || xhr.statusText,
+                xhr.response || xhr.statusText,
                 xhr.getAllResponseHeaders()
             )
         );


### PR DESCRIPTION
The result of onerror(xhr.response) was null, even when response text is present. By removing the onerror() call, this will correctly return xhr.response to the onerror function.