### PR TITLE
* Use `!isFile()` instead of `!(state.file instanceof Blob)` when det…

### DIFF
--- a/src/js/app/utils/createFileProcessorFunction.js
+++ b/src/js/app/utils/createFileProcessorFunction.js
@@ -37,7 +37,7 @@ export const createFileProcessorFunction = (apiUrl, action, name, options) => (f
     if (isObject(metadata)) { formData.append(name, JSON.stringify(metadata)); }
 
     // Turn into an array of objects so no matter what the input, we can handle it the same way
-    (file instanceof Blob ? [{ name: null, file }] : file).forEach(item => {
+    [{ name: null, file }].forEach(item => {
         formData.append(name, item.file, item.name === null ? item.file.name : `${item.name}${item.file.name}`);
     });
 

--- a/src/js/app/utils/createItem.js
+++ b/src/js/app/utils/createItem.js
@@ -99,7 +99,7 @@ export const createItem = (origin = null, serverFileReference = null, file = nul
             fire('load-init');
         });
 
-        // we'eve received a size indication, let's update the stub
+        // we've received a size indication, let's update the stub
         loader.on('meta', meta => {
 
             // set size of file stub
@@ -226,7 +226,7 @@ export const createItem = (origin = null, serverFileReference = null, file = nul
         abortProcessingRequestComplete = null;
 
         // if no file loaded we'll wait for the load event
-        if (!(state.file instanceof Blob)) {
+        if (!isFile(state.file)) {
             api.on('load', () => {
                 process(processor, onprocess);
             });


### PR DESCRIPTION
…ermining if a file has loaded, since in my testing, Edge is presenting a `File` object at this stage, rather than the `Blob` that Chrome etc are presenting (fixes #507).

* If `createFileProcessorFunction` is presented with a file object that is not of type `Blob` (such as `File`, as seen in Edge browser), it attempts to iterate over it using `forEach` as if it were an iterable object, however `File` objects do not have a `forEach` method. Resolve this by treating all file object input into this function as though they are a singular, non-iterable object (fixes #507).

* Fix comment typo.