### PR TITLE
Remove allowSyncAcceptAttribute

### DIFF
--- a/src/js/app/options.js
+++ b/src/js/app/options.js
@@ -46,9 +46,6 @@ export const defaultOptions = {
     // - Does not work with multiple on apple devices
     // - If set, acceptedFileTypes must be made to match with media wildcard "image/*", "audio/*" or "video/*"
 
-    // sync `acceptedFileTypes` property with `accept` attribute
-    allowSyncAcceptAttribute: [true, Type.BOOLEAN],
-
     // Feature toggles
     allowDrop: [true, Type.BOOLEAN], // Allow dropping of files
     allowBrowse: [true, Type.BOOLEAN], // Allow browsing the file system

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -659,10 +659,6 @@ export interface FilePondBaseProps {
      */
     captureMethod?: CaptureAttribute | null;
     /**
-     * Set to false to prevent FilePond from setting the file input field `accept` attribute to the value of the `acceptedFileTypes`.
-     */
-    allowSyncAcceptAttribute?: boolean;
-    /**
      * Enable or disable drag n’ drop.
      * @default true
      */


### PR DESCRIPTION
I just found out that `allowSyncAcceptAttribute` is not used anywhere within filepond project.
