### PR TITLE
Fix exec return null on QQ browser

### DIFF
--- a/src/js/utils/getNonNumeric.js
+++ b/src/js/utils/getNonNumeric.js
@@ -1,1 +1,1 @@
-export const getNonNumeric = str => /[^0-9]+/.exec(str) || [];
+export const getNonNumeric = str => /[^0-9]+/.exec(str) || [','];

--- a/src/js/utils/getNonNumeric.js
+++ b/src/js/utils/getNonNumeric.js
@@ -1,1 +1,1 @@
-export const getNonNumeric = str => /[^0-9]+/.exec(str);
+export const getNonNumeric = str => /[^0-9]+/.exec(str) || [];


### PR DESCRIPTION
method broke this function

```
  var getDecimalSeparator = function getDecimalSeparator() {
    return getNonNumeric((1.1).toLocaleString())[0];
  };
```

becouse in qq browser (1.1).toLocaleString() = ""