### PR TITLE
docs: Fix simple typo, immidiately -> immediately

### DIFF
--- a/dist/filepond.esm.js
+++ b/dist/filepond.esm.js
@@ -1914,7 +1914,7 @@ const defaultOptions = {
   ignoredFiles: [['.ds_store', 'thumbs.db', 'desktop.ini'], Type.ARRAY],
 
   // Upload related
-  instantUpload: [true, Type.BOOLEAN], // Should upload files immidiately on drop
+  instantUpload: [true, Type.BOOLEAN], // Should upload files immediately on drop
   maxParallelUploads: [2, Type.INT], // Maximum files to upload in parallel
 
   // Chunks
@@ -4231,7 +4231,7 @@ const actions = (dispatch, query, state) => ({
         item.abortProcessing().then(doUpload ? upload : () => {});
       };
 
-      // if we should re-upload the file immidiately
+      // if we should re-upload the file immediately
       if (item.status === ItemStatus.PROCESSING_COMPLETE) {
         return revert(state.options.instantUpload);
       }
@@ -4737,7 +4737,7 @@ const actions = (dispatch, query, state) => ({
       return;
     }
 
-    // id we are allowed to upload the file immidiately, lets do it
+    // id we are allowed to upload the file immediately, lets do it
     if (query('IS_ASYNC') && state.options.instantUpload) {
       dispatch('REQUEST_ITEM_PROCESSING', { query: item.id });
     }
@@ -5027,7 +5027,7 @@ const actions = (dispatch, query, state) => ({
   }),
 
   REQUEST_REVERT_ITEM_PROCESSING: getItemByQueryFromState(state, item => {
-    // not instant uploading, revert immidiately
+    // not instant uploading, revert immediately
     if (!state.options.instantUpload) {
       dispatch('REVERT_ITEM_PROCESSING', { query: item });
       return;
@@ -7324,7 +7324,7 @@ const guesstimateMimeType = (extension = '') => {
 
 const requestDataTransferItems = dataTransfer =>
   new Promise((resolve, reject) => {
-    // try to get links from transfer, if found we'll exit immidiately (unless a file is in the dataTransfer as well, this is because Firefox could represent the file as a URL and a file object at the same time)
+    // try to get links from transfer, if found we'll exit immediately (unless a file is in the dataTransfer as well, this is because Firefox could represent the file as a URL and a file object at the same time)
     const links = getLinks(dataTransfer);
     if (links.length && !hasFiles(dataTransfer)) {
       return resolve(links);
@@ -9666,7 +9666,7 @@ const hasCSSSupports = () => 'supports' in (window.CSS || {}); // use to detect 
 const isIE11 = () => /MSIE|Trident/.test(window.navigator.userAgent);
 
 const supported = (() => {
-  // Runs immidiately and then remembers result for subsequent calls
+  // Runs immediately and then remembers result for subsequent calls
   const isSupported =
     // Has to be a browser
     isBrowser() &&

--- a/dist/filepond.js
+++ b/dist/filepond.js
@@ -3948,7 +3948,7 @@
     ignoredFiles: [['.ds_store', 'thumbs.db', 'desktop.ini'], Type.ARRAY],
 
     // Upload related
-    instantUpload: [true, Type.BOOLEAN], // Should upload files immidiately on drop
+    instantUpload: [true, Type.BOOLEAN], // Should upload files immediately on drop
     maxParallelUploads: [2, Type.INT], // Maximum files to upload in parallel
 
     // Chunks
@@ -6664,7 +6664,7 @@
             item.abortProcessing().then(doUpload ? upload : function() {});
           };
 
-          // if we should re-upload the file immidiately
+          // if we should re-upload the file immediately
           if (item.status === ItemStatus.PROCESSING_COMPLETE) {
             return revert(state.options.instantUpload);
           }
@@ -7219,7 +7219,7 @@
           return;
         }
 
-        // id we are allowed to upload the file immidiately, lets do it
+        // id we are allowed to upload the file immediately, lets do it
         if (query('IS_ASYNC') && state.options.instantUpload) {
           dispatch('REQUEST_ITEM_PROCESSING', { query: item.id });
         }
@@ -7540,7 +7540,7 @@
       REQUEST_REVERT_ITEM_PROCESSING: getItemByQueryFromState(state, function(
         item
       ) {
-        // not instant uploading, revert immidiately
+        // not instant uploading, revert immediately
         if (!state.options.instantUpload) {
           dispatch('REVERT_ITEM_PROCESSING', { query: item });
           return;
@@ -10150,7 +10150,7 @@
     dataTransfer
   ) {
     return new Promise(function(resolve, reject) {
-      // try to get links from transfer, if found we'll exit immidiately (unless a file is in the dataTransfer as well, this is because Firefox could represent the file as a URL and a file object at the same time)
+      // try to get links from transfer, if found we'll exit immediately (unless a file is in the dataTransfer as well, this is because Firefox could represent the file as a URL and a file object at the same time)
       var links = getLinks(dataTransfer);
       if (links.length && !hasFiles(dataTransfer)) {
         return resolve(links);
@@ -12771,7 +12771,7 @@
   };
 
   var supported = (function() {
-    // Runs immidiately and then remembers result for subsequent calls
+    // Runs immediately and then remembers result for subsequent calls
     var isSupported =
       // Has to be a browser
       isBrowser() &&

--- a/src/js/app/actions.js
+++ b/src/js/app/actions.js
@@ -183,7 +183,7 @@ export const actions = (dispatch, query, state) => ({
                 .then(doUpload ? upload : () => {});
             }
     
-            // if we should re-upload the file immidiately
+            // if we should re-upload the file immediately
             if (item.status === ItemStatus.PROCESSING_COMPLETE) {
                 return revert(state.options.instantUpload);
             }
@@ -682,7 +682,7 @@ export const actions = (dispatch, query, state) => ({
             return;
         }
 
-        // id we are allowed to upload the file immidiately, lets do it
+        // id we are allowed to upload the file immediately, lets do it
         if (query('IS_ASYNC') && state.options.instantUpload) {
             dispatch('REQUEST_ITEM_PROCESSING', { query: item.id });
         }
@@ -944,7 +944,7 @@ export const actions = (dispatch, query, state) => ({
 
     REQUEST_REVERT_ITEM_PROCESSING: getItemByQueryFromState(state, item => {
 
-        // not instant uploading, revert immidiately
+        // not instant uploading, revert immediately
         if (!state.options.instantUpload) {
             dispatch('REVERT_ITEM_PROCESSING', { query: item });
             return;

--- a/src/js/app/options.js
+++ b/src/js/app/options.js
@@ -80,7 +80,7 @@ export const defaultOptions = {
     ignoredFiles: [['.ds_store', 'thumbs.db', 'desktop.ini'], Type.ARRAY],
 
     // Upload related
-    instantUpload: [true, Type.BOOLEAN], // Should upload files immidiately on drop
+    instantUpload: [true, Type.BOOLEAN], // Should upload files immediately on drop
     maxParallelUploads: [2, Type.INT], // Maximum files to upload in parallel
     
     // Chunks

--- a/src/js/app/utils/requestDataTransferItems.js
+++ b/src/js/app/utils/requestDataTransferItems.js
@@ -3,7 +3,7 @@ import { getExtensionFromFilename } from '../../utils/getExtensionFromFilename';
 
 export const requestDataTransferItems = dataTransfer =>
     new Promise((resolve, reject) => {
-        // try to get links from transfer, if found we'll exit immidiately (unless a file is in the dataTransfer as well, this is because Firefox could represent the file as a URL and a file object at the same time)
+        // try to get links from transfer, if found we'll exit immediately (unless a file is in the dataTransfer as well, this is because Firefox could represent the file as a URL and a file object at the same time)
         const links = getLinks(dataTransfer);
         if (links.length && !hasFiles(dataTransfer)) {
             return resolve(links);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -22,7 +22,7 @@ const isIE11 = () => /MSIE|Trident/.test(window.navigator.userAgent);
 
 export const supported = (() => {
 
-    // Runs immidiately and then remembers result for subsequent calls
+    // Runs immediately and then remembers result for subsequent calls
     const isSupported = 
 
         // Has to be a browser


### PR DESCRIPTION
There is a small typo in dist/filepond.esm.js, dist/filepond.js, src/js/app/actions.js, src/js/app/options.js, src/js/app/utils/requestDataTransferItems.js, src/js/index.js.

Should read `immediately` rather than `immidiately`.

