### PR TITLE
Fix nested folder drop when beforeAddFile is false

### DIFF
--- a/src/js/app/view/data.js
+++ b/src/js/app/view/data.js
@@ -36,7 +36,9 @@ const didSetDisabled = ({ root }) => {
 const didRemoveItem = ({ root, action }) => {
     const field = getField(root, action.id);
     if (!field) return;
-    field.parentNode.removeChild(field);
+    if (field.parentNode) {
+        field.parentNode.removeChild(field);
+    }
     delete root.ref.fields[action.id];
 };
 


### PR DESCRIPTION
### Fixed

When trying to drop a folder with nested folders inside but for some reason, the `beforeAddFile` hook return value is false. We get this error.

```
Uncaught TypeError: Cannot read property 'removeChild' of null
```

Here is an example: https://jsfiddle.net/9vb3cf75/