### PR TITLE
simplify code contributions by fully automating the dev setup with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks:
+  - init: npm install && npm run build
+    command: npm run start

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A JavaScript library that can upload anything you throw at it, optimizes images 
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/pqina/filepond/blob/master/LICENSE)
 [![npm version](https://badge.fury.io/js/filepond.svg)](https://www.npmjs.com/package/filepond)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 21 KB gzipped. FilePond adapters are available for **[React](https://github.com/pqina/react-filepond)**, **[Vue](https://github.com/pqina/vue-filepond)**, **[Angular](https://github.com/pqina/ngx-filepond)** and **[jQuery](https://github.com/pqina/jquery-filepond)**
 
@@ -148,6 +149,9 @@ Tests are based on Jest and can be run with `npm run test`
 
 To build the library run `npm run build`
 
+### Online one-click setup for Contributing
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 ## Publications
 


### PR DESCRIPTION
Hi. I work for Gitpod(an online IDE which is free for Open Source) and we are currently on a mission to simplify contributors onboarding experience for cool and popular Open Source projects.

This Pr adds Gitpod config to the repo via which, anyone would be able to launch a workspace where it will automatically:

- clone the `filepond` repo.
- install the dependencies via `npm install`.
- run `npm run build`.
- run `npm run start`.

All of this can be helpful for newcomers/beginners i.e they can start in just a single click without having to set anything up.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/filepond

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/96348467-6dfe1500-10c2-11eb-8750-a2a667e1b88c.png)

