### PR TITLE
Add typing for fileSizeBase

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -741,6 +741,11 @@ export interface FilePondBaseProps {
      * @default 75
      */
     itemInsertInterval?: number;
+    /**
+     * The base value used to calculate file size
+     * @default 1000
+     */
+    fileSizeBase?: number;
 }
 
 // TODO delete


### PR DESCRIPTION
This PR adds typing for `fileSizeBase` introduced in v4.21.0. Thanks!