### PR TITLE
Fixed no response return onload callback

### DIFF
--- a/src/js/app/utils/createFileProcessorFunction.js
+++ b/src/js/app/utils/createFileProcessorFunction.js
@@ -48,7 +48,7 @@ export const createFileProcessorFunction = (apiUrl, action, name, options) => (f
             createResponse(
                 'load',
                 xhr.status,
-                onload(xhr.response),
+                onload(xhr.response) || xhr.response,
                 xhr.getAllResponseHeaders()
             )
         );


### PR DESCRIPTION
If there is nothing return from `onload` callback, use `xhr.response` by default