### PR TITLE
Fix the chunkRetryDelays option

### DIFF
--- a/src/js/app/options.js
+++ b/src/js/app/options.js
@@ -87,7 +87,7 @@ export const defaultOptions = {
     chunkUploads: [false, Type.BOOLEAN], // Enable chunked uploads
     chunkForce: [false, Type.BOOLEAN], // Force use of chunk uploads even for files smaller than chunk size
     chunkSize: [5000000, Type.INT], // Size of chunks (5MB default)
-    chunkRetryDelays: [[500, 1000, 3000], Type.Array], // Amount of times to retry upload of a chunk when it fails
+    chunkRetryDelays: [[500, 1000, 3000], Type.ARRAY], // Amount of times to retry upload of a chunk when it fails
 
     // The server api end points to use for uploading (see docs)
     server: [null, Type.SERVER_API],


### PR DESCRIPTION
Currently, the `chunkRetryDelays` option doesn't work. This is because there is a typo in the options definition where the type is set as `Type.Array`, but the Type object only has the key `Type.ARRAY`.

Therefore the type of the `chunkRetryDelays` is undefined which breaks the code which takes care of changing this option.