### PR TITLE
Improve stylePanelLayout type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -583,7 +583,7 @@ export interface FilePondStyleProps {
      * Set a different layout render mode.
      * @default null
      */
-    stylePanelLayout?: 'integrated' | 'compact' | 'circle' | null;
+    stylePanelLayout?: 'integrated' | 'compact' | 'circle' | 'integrated circle' | 'compact circle' | null;
     /**
      * Set a forced aspect ratio for the FilePond drop area.
      *


### PR DESCRIPTION
The documentation says `Set a different layout render mode. Can be either 'integrated', 'compact', and/or 'circle'.` So we can combine `integrated` and `compact` with `circle`?