### PR TITLE
OnError callback test

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "cssnano": "^4.1.10",
         "dtslint": "^3.6.12",
         "jest": "^24.8.0",
+        "jest-mock-console": "^1.2.3",
         "postcss-cli": "^6.1.3",
         "precss": "^4.0.0",
         "prettier": "^1.18.2",

--- a/src/js/__tests__/callbacks.test.js
+++ b/src/js/__tests__/callbacks.test.js
@@ -1,3 +1,5 @@
+import mockConsole from "jest-mock-console";
+
 import './windowMatchMedia.mock';
 import { create, OptionTypes, FileStatus } from '../index.js';
 
@@ -11,7 +13,6 @@ describe('adding files', () => {
         }
 
         pond = create({
-            ...options,
             server: {
                 process: (fieldName, file, metadata, load, error, progress, abort) => {
                     let p = 0;
@@ -31,7 +32,8 @@ describe('adding files', () => {
                         },
                     };
                 },
-            },
+            },            
+            ...options,
         });
 
         // enables draw loop, else it seems that filepond is hidden and it won't run
@@ -70,6 +72,22 @@ describe('adding files', () => {
             done();
         };
         pond.addFile(data);
+    });
+
+    test('onerror', done => {
+        // we don't want the console error about the server call failure to muddy up the console
+        const restoreConsole = mockConsole();
+
+        createPond({
+            server: './invalid-path'
+        });
+        pond.onerror = () => {
+            done();
+        };
+        pond.addFile(data);
+
+        // restore the console back to normal so that real issues aren't hidden
+        restoreConsole();
     });
 
     test('onremovefile', done => {


### PR DESCRIPTION
This pull request adds test coverage for the `onerror` callback. 

In order to prevent an expected console error from muddying up the console (and possibly making it harder to see errors that do need to be dealt with), a new dependency is added on `jest-mock-console`. This new test then specifically mocks the console for the duration of that test, preventing any messaging about the server call failure from being written to the console.

Additionally, the existing `createPond()` function was updated, allowing for the provided options from a given test being able to also override the server configuration (which then set up forcing an error, such that the `onerror` callback could be test).