### PR TITLE
Added export namespace in types file.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,6 +4,8 @@
 /* Disable no-redundant-jsdoc since @default statements are NOT redundant */
 /* tslint:disable:no-redundant-jsdoc */
 
+export as namespace FilePond;
+
 export { };
 
 export enum FileStatus {


### PR DESCRIPTION
For some projects, for example for TypeScript in ASP.NET project without using of webpack or similar, exports are not recognized when import cannot be used. 
With namespace all works fine.