### PR TITLE
Allow use of type without import (namespace)

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,6 +4,8 @@
 /* Disable no-redundant-jsdoc since @default statements are NOT redundant */
 /* tslint:disable:no-redundant-jsdoc */
 
+export as namespace filepond;
+
 export { };
 
 export enum FileStatus {


### PR DESCRIPTION
Types not working when in destination project use of import are not required.
If I use imports in my project Typescript compiler generate "__esmodule" lines and this cause errors because undeclare variables.
With adding export as namespace typescript with some tsconfig.json configurations types are recognized without use of import.
I create a sample project, where I edited filepond's type file to test this edit.
https://github.com/simusr2/TestTypeScript