### PR TITLE
Immediately schedule destruction of view.element on unmount

### DIFF
--- a/src/js/app/index.js
+++ b/src/js/app/index.js
@@ -566,7 +566,16 @@ export const createApp = (initialOptions = {}) => {
          */
         destroy: () => {
             // request destruction
-            exports.fire('destroy', view.element);
+            var indexToRemove = state.apps.findIndex(function (app) {
+                return app.isAttachedTo(view.element);
+            });
+            if (indexToRemove >= 0) {
+                // remove from apps
+                var app = state.apps.splice(indexToRemove, 1)[0];
+
+                // restore original dom element
+                app.restoreElement();
+            }
 
             // stop active processes (file uploads, fetches, stuff like that)
             // loop over items and depending on states call abort for ongoing processes


### PR DESCRIPTION
Just illustrating the root of the problem for https://github.com/pqina/react-filepond/issues/207. Not a merge-able fix but a fix nonetheless. Feel free to close upon read.

With StrictMode, React renders each component twice: specifically mount, unmount, mount. The crux of the issue is that `exports.fire('destroy', view.element)` is not scheduled to execute the underlying function before the second component mount is called. This means that filepond is trying to manipulate already manipulated DOM elements and fails.