### PR TITLE
Fix a bug where the onwarning event is not triggered

### DIFF
--- a/src/js/app/view/root.js
+++ b/src/js/app/view/root.js
@@ -422,6 +422,10 @@ const exceedsMaxFiles = (root, items) => {
 
     // if does not allow multiple items and dragging more than one item
     if (!allowMultiple && totalBrowseItems > 1) {
+        root.dispatch('DID_THROW_MAX_FILES', {
+            source: items,
+            error: createResponse('warning', 0, 'Max files'),
+        });
         return true;
     }
 


### PR DESCRIPTION
Fixes #838
Trigger the onwarning event when allowMultiple is false and you drag more
than one file.