### PR TITLE
Fix a bug where the selected file is not replaced

### DIFF
--- a/src/js/app/view/root.js
+++ b/src/js/app/view/root.js
@@ -426,7 +426,12 @@ const exceedsMaxFiles = (root, items) => {
     }
 
     // limit max items to one if not allowed to drop multiple items
-    maxItems = allowMultiple ? maxItems : allowReplace ? maxItems : 1;
+    maxItems = allowMultiple ? maxItems : 1;
+
+    if (!allowMultiple && allowReplace) {
+        // There is only one item, so there is room to replace or add an item
+        return false;
+    }
 
     // no more room?
     const hasMaxItems = isInt(maxItems);


### PR DESCRIPTION
Fixes #840 
When enabled, allow replace regardless of the maxFiles value.