### PR TITLE
docs: switch unpkg to jsdelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Or get it from a CDN:
   <title>FilePond from CDN</title>
 
   <!-- Filepond stylesheet -->
-  <link href="https://unpkg.com/filepond/dist/filepond.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/filepond@4/dist/filepond.css" rel="stylesheet">
 
 </head>
 <body>
@@ -127,7 +127,7 @@ Or get it from a CDN:
   <input type="file" class="filepond">
 
   <!-- Load FilePond library -->
-  <script src="https://unpkg.com/filepond/dist/filepond.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/filepond@4/dist/filepond.js"></script>
 
   <!-- Turn all file input elements into ponds -->
   <script>


### PR DESCRIPTION
unpkg is unmaintained and [full of issues](https://github.com/mjackson/unpkg/issues). I switched the documentation over to [jsDelivr](https://www.jsdelivr.com/) since it's actively maintained and is much more reliable due to its [fallback system](https://www.jsdelivr.com/network/infographic).

I also added a fixed version tag `@4` to prevent users from accidentally updating should there ever be a breaking version `@5` released.

Let me know if there are any concerns!