### PR TITLE
Add filepond-rails as a backend option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ FilePond adapters are available for **[React](https://github.com/pqina/react-fil
 *   [Laravel](https://github.com/Sopamo/laravel-filepond) ([Sopamo/laravel-filepond](https://github.com/Sopamo/laravel-filepond))
 *   [Laravel](https://github.com/Albert221/laravel-filepond) ([Albert221/laravel-filepond](https://github.com/Albert221/laravel-filepond))
 *   [SilverStripe](https://github.com/lekoala/silverstripe-filepond) ([lekoala/silverstripe-filepond](https://github.com/lekoala/silverstripe-filepond))
+*   [Ruby on Rails](https://github.com/Code-With-Rails/filepond-rails) ([Code-With-Rails/filepond-rails](https://github.com/Code-With-Rails/filepond-rails))
 
 ## Quick Start
 


### PR DESCRIPTION
I published a gem several weeks' back to integrate FilePond with Rails, and finally had the chance to add some tests to the gem library itself.

Submitting adding the gem as a backend option for Rails developers.

Thank you!