### PR TITLE
fix: improve types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -327,7 +327,7 @@ export interface FilePondServerConfigProps {
      * See: https://pqina.nl/filepond/docs/patterns/api/filepond-object/#setting-initial-files
      * @default []
      */
-    files?: Array<FilePondInitialFile | ActualFileObject | Blob | string>;
+    files?: Array<FilePondInitialFile | FilePondFile | ActualFileObject | Blob | string>;
 }
 
 export interface FilePondDragDropProps {


### PR DESCRIPTION
> While the files property can also be populated with new files, it is advised to add new files using only the addFile and addFiles methods.

When using React or other cases, such as a quickstart example:

```tsx
const [files, setFiles] = useState<FilePondFile[]>([]);

<FilePond
  files={files}
  onupdatefiles={(files) => setFiles(files)}
/>
```

This will throw a type error because:

```ts
files?: Array<FilePondInitialFile | ActualFileObject | Blob | string>;
onupdatefiles?: ((files: FilePondFile[]) => void)
```