### PR TITLE
Add ckb locale

### DIFF
--- a/locale/kur-ckb.js
+++ b/locale/kur-ckb.js
@@ -1,0 +1,46 @@
+export default {
+    labelIdle:
+      'فایلەکانت ڕابکێشە یان <span class="filepond--label-action"> دیاری بکە </span>',
+    labelInvalidField: "هەڵبژاردنەکان فایلی نادروستی تێدایە",
+    labelFileWaitingForSize: "چاوەڕوانکردنی قەبارە",
+    labelFileSizeNotAvailable: "قەبارە بەردەست نییە",
+    labelFileLoading: "چاوەڕوان بە",
+    labelFileLoadError: "هەڵەیەک ڕوویدا لە کاتی خوێندنەوە",
+    labelFileProcessing: "بارکردن",
+    labelFileProcessingComplete: "بارکردن سەرکەوتو بوو",
+    labelFileProcessingAborted: "بارکردن پاشگەزکرایەوە",
+    labelFileProcessingError: "هەڵەیەک ڕوویدا لەکاتی بارکردن",
+    labelFileProcessingRevertError: "هەڵەیەک ڕوویدا لەکاتی گەڕاندنەوە",
+    labelFileRemoveError: "هەڵەیەک ڕوویدا لەکاتی سڕینەوە",
+    labelTapToCancel: "کلیک بۆ پاشگەزبوونەوە",
+    labelTapToRetry: "کلیک بۆ دووبارەکردنەوە",
+    labelTapToUndo: "کلیک بۆ گەڕاندنەوە",
+    labelButtonRemoveItem: "سڕینەوە",
+    labelButtonAbortItemLoad: "لەباربردن",
+    labelButtonRetryItemLoad: "دووبارەکردنەوە",
+    labelButtonAbortItemProcessing: "پاشگەزکردنەوە",
+    labelButtonUndoItemProcessing: "گەڕاندنەوە",
+    labelButtonRetryItemProcessing: "دووبارەکردنەوە",
+    labelButtonProcessItem: "بارکردن",
+    labelMaxFileSizeExceeded: "قەبارەی فایلەکە زۆرە",
+    labelMaxFileSize: "قەبارەی فایل پێویستە لە {filesize} کەمتر بێت",
+    labelMaxTotalFileSizeExceeded: "قەبارەی فایل زۆر زیاترە لە قەبارەی دیاریکراو",
+    labelMaxTotalFileSize:
+      "کۆی گشتی قەبارەی فایل پێویستە لە {filesize} کەمتر بێت",
+    labelFileTypeNotAllowed: "جۆری فایل نادروستە",
+    fileValidateTypeLabelExpectedTypes:
+      "چاوەڕوانی {allButLastType} یان {lastType} کرا",
+    imageValidateSizeLabelFormatError: "جۆری وێنە نادروستە",
+    imageValidateSizeLabelImageSizeTooSmall: "وێنە زۆر بچووکە",
+    imageValidateSizeLabelImageSizeTooBig: "وێنە زۆر گەورەیە",
+    imageValidateSizeLabelExpectedMinSize:
+      "کەمترین پانی و بەرزی پێویستە {minWidth} × {minHeight} بیت",
+    imageValidateSizeLabelExpectedMaxSize:
+      "زۆرترین پانی و بەرزی پێویستە {maxWidth} × {maxHeight} بێت",
+    imageValidateSizeLabelImageResolutionTooLow: "چوارچێوەکە زۆر کەمە",
+    imageValidateSizeLabelImageResolutionTooHigh: "چوارچێوەکە زۆر بەرزە",
+    imageValidateSizeLabelExpectedMinResolution:
+      "کەمترین چوارچێوە پێویستە {minResolution} بێت",
+    imageValidateSizeLabelExpectedMaxResolution:
+      "بەرزترین چوارچێوە پێویستە {maxResolution} بێت",
+};


### PR DESCRIPTION
Hey there!

This PR adds `ckb` locale to the list of supported locales.

**The locale is picked with the following references:**
- [Picking the right language identifier by Unicode CLDR](https://cldr.unicode.org/index/cldr-spec/picking-the-right-language-code)
- [CKB in Glottolog](https://glottolog.org/resource/languoid/id/cent1972)
- [CKB in Ethnologue](https://www.ethnologue.com/language/ckb/)
- [CKB in ISO 639-3](https://iso639-3.sil.org/code/ckb)

Thank you!