### PR TITLE
Do not attempt to set value if the field is a file field

### DIFF
--- a/src/js/app/view/data.js
+++ b/src/js/app/view/data.js
@@ -63,7 +63,8 @@ const didRemoveItem = ({ root, action }) => {
     delete root.ref.fields[action.id];
 };
 
-// only runs for server files (so doesn't deal with file input)
+// only runs for server files. will refuse to update the value if the field
+// is a file field
 const didDefineValue = ({ root, action }) => {
     const field = getField(root, action.id);
     if (!field) return;
@@ -72,7 +73,9 @@ const didDefineValue = ({ root, action }) => {
         field.removeAttribute('value');
     } else {
         // set field value
-        field.value = action.value;
+        if (field.type != 'file') {
+            field.value = action.value;
+        }
     }
     syncFieldPositionsWithItems(root);
 };


### PR DESCRIPTION
From the comment, the function assumed that it would never get a file field. It was probably true before 'storeAsFile', but no longer true as of today.

Will probably fix https://github.com/pqina/filepond/issues/905