### PR TITLE
aria-hidden-removed

### DIFF
--- a/src/js/app/view/dropLabel.js
+++ b/src/js/app/view/dropLabel.js
@@ -12,9 +12,6 @@ const create = ({ root, props }) => {
     // use for labeling file input (aria-labelledby on file input)
     attr(label, 'id', `filepond--drop-label-${props.id}`);
 
-    // hide the label for screenreaders, the input element will read the contents of the label when it's focussed. If we don't set aria-hidden the screenreader will also navigate the contents of the label separately from the input.
-    attr(label, 'aria-hidden', 'true');
-
     // handle keys
     root.ref.handleKeyDown = e => {
         const isActivationKey = e.keyCode === Key.ENTER || e.keyCode === Key.SPACE;

--- a/src/js/app/view/root.js
+++ b/src/js/app/view/root.js
@@ -104,7 +104,6 @@ const create = ({ root, props }) => {
     if (hasCredits) {
         const frag = document.createElement('a');
         frag.className = 'filepond--credits';
-        frag.setAttribute('aria-hidden', 'true');
         frag.href = credits[0];
         frag.tabindex = -1;
         frag.target = '_blank';


### PR DESCRIPTION
Removed aria-hidden to fix the bug, elements contain the focusable descendants. From the issue #922.