### PR TITLE
Add typing for FilePondBaseProps.allowRemove

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -722,6 +722,11 @@ export interface FilePondBaseProps {
      */
     allowRevert?: boolean;
     /**
+     * When set to false the remove button is hidden and disabled.
+     * @default true
+     */
+    allowRemove?: boolean;
+    /**
      * Allows user to process a file. When set to false, this removes the file upload button.
      * @default true
      */


### PR DESCRIPTION
Fixes pqina/react-filepond#238

`react-filepond` uses `FilePondOptions` as which in turn extends `FilePondBaseProps`.

https://github.com/pqina/react-filepond/blob/3af941f87cf86afa6dcf5553c8fb566c00b7f1d9/types/index.d.ts#L40-L44

https://github.com/pqina/filepond/blob/14f15045d8751366bd262ef853a2b52c31b4e5d2/types/index.d.ts#L810-L818

