### PR TITLE
Add "patch" config option to FilePondServerConfigProps.server

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -298,6 +298,7 @@ export interface FilePondServerConfigProps {
         restore?: string | ServerUrl | RestoreServerConfigFunction | null;
         load?: string | ServerUrl | LoadServerConfigFunction | null;
         fetch?: string | ServerUrl | FetchServerConfigFunction | null;
+        patch?: string | ServerUrl | null;
         remove?: RemoveServerConfigFunction | null;
     } | null;
 


### PR DESCRIPTION
"patch" is in the [docs](https://pqina.nl/filepond/docs/api/server/#url) and works correctly when specified, but not in the TypeScript definition.