### PR TITLE
Allow drag and drop on external element

### DIFF
--- a/src/js/app/options.js
+++ b/src/js/app/options.js
@@ -81,6 +81,7 @@ export const defaultOptions = {
 
     // Drag 'n Drop related
     dropOnPage: [false, Type.BOOLEAN], // Allow dropping of files anywhere on page (prevents browser from opening file if dropped outside of Up)
+    dropOnExternal: [null, Type.STRING], // Specify ID of another element for user to drag and drop into. Will disable drag and drop of root element
     dropOnElement: [true, Type.BOOLEAN], // Drop needs to happen on element (set to false to also load drops outside of Up)
     dropValidation: [false, Type.BOOLEAN], // Enable or disable validating files on drop
     ignoredFiles: [['.ds_store', 'thumbs.db', 'desktop.ini'], Type.ARRAY],

--- a/src/js/app/view/root.js
+++ b/src/js/app/view/root.js
@@ -467,8 +467,17 @@ const toggleDrop = root => {
     const isDisabled = root.query('GET_DISABLED');
     const enabled = isAllowed && !isDisabled;
     if (enabled && !root.ref.hopper) {
+        let scopeElement = root.element;
+        let externalElementID = root.query('GET_DROP_ON_EXTERNAL');
+        if (externalElementID) {
+            if (document.getElementById(externalElementID)) {
+                scopeElement = document.getElementById(externalElementID);
+            } else {
+                console.error("Element does not exist, will revert to root element for drag and drop",externalElementID)
+            }
+        }
         const hopper = createHopper(
-            root.element,
+            scopeElement,
             items => {
                 // allow quick validation of dropped items
                 const beforeDropFile = root.query('GET_BEFORE_DROP_FILE') || (() => true);


### PR DESCRIPTION
Hi,

It is me again.  Just want to say thanks for the beautiful uploader.

I created this PR to support drag and drop on an external element (an element that is outside the main FilePond element where the posters are shown)

There are several reasons behind it

I note from another Issues opened about 2 years ago that drag-and-drop from an outside element is not supported and that the dev may have to use two FilePonds and sync across the file.  This got me thinking, why not just change the target of the drag-and-drop event listener?  Thus I came up with this solution, which seems to only affect the drag-and-drop behaviour and nothing else.  Also, when dropOnExternal is not set, it preserves the original behaviour 100%

I think FilePond has the potential to become a very good "file gallery" because of its support for drag-to-rearrange file, adding mock file from virtually any source, and a very good plugin system.  Plus it is beautiful out of the box.

I plan to use filepond to manage upload from different sources, such as from filepond, from server's data about previous uploads and from device camera.  A user will have the chance to use pintura on some of the files, regardless of whether it is uploaded by filepond itself.

After the upload, a user can perform certain actions (the code of which I have already given in the latest Issues) from the main filepond.  Such action include - download the file back (for example after a pintura edit), send to email using backend and more

For a cleaner UI, and to tell users that there are more than 1 way to upload file, I need to separate the upload component of filepond from the "gallery" component.  This is the reason for the PR

As a side note:  of the big three (Dropzone, FilePond and Uppy)
only FilePond support drag and drop to rearrange file order natively.  Uppy has said they are not considering the gallery function I have in mind so I think FilePond has the real edge here.