### PR TITLE
Fix paste being used in wrong container

### DIFF
--- a/src/js/app/utils/createPaster.js
+++ b/src/js/app/utils/createPaster.js
@@ -10,7 +10,8 @@ const handlePaste = e => {
     const isActiveElementEditable =
         activeEl &&
         (/textarea|input/i.test(activeEl.nodeName) ||
-            activeEl.getAttribute('contenteditable') === 'true');
+            activeEl.getAttribute('contenteditable') === 'true' ||
+            activeEl.getAttribute('contenteditable') === '');
 
     if (isActiveElementEditable) {
         // test textarea or input is contained in filepond root


### PR DESCRIPTION
So i'm using Filament/filament and they aren't allowing the use of allowPaste as the RichEditor in that package uses the attribute contenteditable WITHOUT a value. 

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable

[Value](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable#value)
The attribute must take one of the following values:

true or **an empty string**, which indicates that the element is editable.

So the prevous fix only handles when the value is true, but a <textarea contenteditable is the same as <textarea contenteditable="true"

I propose my change should fix a few others