### PR TITLE
fix: Fix drop item position mismatch when filepond container contains…

### DIFF
--- a/src/js/app/view/list.js
+++ b/src/js/app/view/list.js
@@ -132,8 +132,8 @@ const removeItemView = ({ root, action }) => {
 
 const getItemHeight = child =>
     child.rect.element.height +
-    child.rect.element.marginBottom * 0.5 +
-    child.rect.element.marginTop * 0.5;
+    child.rect.element.marginBottom +
+    child.rect.element.marginTop;
 const getItemWidth = child =>
     child.rect.element.width +
     child.rect.element.marginLeft * 0.5 +


### PR DESCRIPTION
Fix issue #1052


![issue-1052](https://github.com/user-attachments/assets/04445884-ca6e-442d-9677-ccb0ea04e1aa)

Sample: https://jsfiddle.net/y24vqj8a/

Fix drop item position mismatch when filepond container contains many file items.