### PR TITLE
Fix FileExtensionValidator failing to validate upper case file-extensions

### DIFF
--- a/src/extensions/file-extension-validator.ts
+++ b/src/extensions/file-extension-validator.ts
@@ -53,8 +53,8 @@ export const FileExtensionValidator = createValidatorExtension({
                 };
             }
 
-            // get entry extension
-            const extension = getExtensionFromFilename(name);
+            // get entry extension (case insensitive)
+            const extension = getExtensionFromFilename(name, true);
 
             // match types
             const didMatchSome = computedExtensions.some((ext) => ext === extension);

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -43,8 +43,9 @@ export function sanitizeFilename(filename: string) {
 }
 
 /** Returns extension + preceding dot, `test.txt` returns `.txt` */
-export function getExtensionFromFilename(filename: unknown): string | undefined {
-    return isString(filename) ? /(?:\.([^.]+))?$/.exec(filename)?.[0] : undefined;
+export function getExtensionFromFilename(filename: unknown, caseInsensitive = false): string | undefined {
+    const extension = isString(filename) ? /(?:\.([^.]+))?$/.exec(filename)?.[0] : undefined;
+    return caseInsensitive ? extension?.toLowerCase() : extension;
 }
 
 export function getFilenameWithoutExtension(filename: string): string | undefined {

--- a/test/extensions/file-extension-validator.test.js
+++ b/test/extensions/file-extension-validator.test.js
@@ -34,4 +34,31 @@ describe('FileExtensionValidator', () => {
 
             entryTree.entries = [{ src: new File([''], 'foo.txt', { type: 'text/plain' }) }];
         }));
+
+    it('should accept files with upper case extension', () =>
+        new Promise((done) => {
+            entryTree = createDefaultEntryTree();
+            extensionManager = createExtensionManager(entryTree);
+            extensionManager.extensions = [
+                [
+                    FileExtensionValidator,
+                    {
+                        accept: ['.txt'],
+                    },
+                ],
+            ];
+
+            const unsub = entryTree.on('updateEntry', (entry) => {
+                const {
+                    FileExtensionValidator: { status },
+                } = entry.extension;
+
+                if (status?.code !== 'VALIDATION_COMPLETE') return;
+
+                unsub();
+                done();
+            });
+
+            entryTree.entries = [{ src: new File([''], 'foo.TXT', { type: 'text/plain' }) }];
+        }));
 });

--- a/test/utils/getExtensionFromFilename.test.js
+++ b/test/utils/getExtensionFromFilename.test.js
@@ -18,6 +18,14 @@ describe('getExtensionFromFilename', function () {
         expect(getExtensionFromFilename('name.txt.txt')).to.equal('.txt');
     });
 
+    it('should parse "name.TXT" (case sensitive)', function () {
+        expect(getExtensionFromFilename('name.TXT')).to.equal('.TXT');
+    });
+
+    it('should parse "name.TXT" (case insensitive)', function () {
+        expect(getExtensionFromFilename('name.TXT', true)).to.equal('.txt');
+    });
+
     it('should parse "name"', function () {
         expect(getExtensionFromFilename('name')).to.equal('');
     });


### PR DESCRIPTION
I added a 2nd *optional* parameter to `getExtensionFromFilename` called `caseInsensitive` (`false` by default) to allow returning file extensions as lower case. This is mainly for the `FileExtensionValidator` extension.

The function `getExtensionFromFilename` is also used in the `FileNameTransform` extension, there I am calling the function without the `caseInsensitive` flag, to give users full control over the original filename.

I also added tests.

If anything is missing or not to your liking, please tell me. Thank you!