### PR TITLE
Fix Norwegian (no_nb) remove-error label

### DIFF
--- a/locale/no_nb.js
+++ b/locale/no_nb.js
@@ -10,7 +10,7 @@ export default {
     labelFileProcessingAborted: 'Opplasting avbrutt',
     labelFileProcessingError: 'Feil under opplasting',
     labelFileProcessingRevertError: 'Feil under reversering',
-    labelFileRemoveError: 'Feil under flytting',
+    labelFileRemoveError: 'Feil under fjerning',
     labelTapToCancel: 'klikk for å avbryte',
     labelTapToRetry: 'klikk for å prøve på nytt',
     labelTapToUndo: 'klikk for å angre',


### PR DESCRIPTION
`labelFileRemoveError` in the Norwegian Bokmål locale read "Feil under flytting" — *"Error during moving"*, which is the wrong action. It should refer to removal, matching the existing `labelButtonRemoveItem: 'Fjern'`.

Changed it to **"Feil under fjerning"** (*"Error during removal"*).

I'm a native Norwegian (Bokmål) speaker; spotted with AI assistance (Claude) and verified by me.