### PR TITLE
Append a guessed extension when the loaded filename has none

### DIFF
--- a/src/js/__tests__/getFileFromBlob.test.js
+++ b/src/js/__tests__/getFileFromBlob.test.js
@@ -1,0 +1,26 @@
+import { getFileFromBlob } from '../utils/getFileFromBlob';
+
+const blob = (type) => new Blob(['x'], { type });
+
+describe('getFileFromBlob filename/extension handling', () => {
+    test('appends a guessed extension when the filename has none', () => {
+        // e.g. loading https://example.com/files/avatar that responds with image/png
+        const file = getFileFromBlob(blob('image/png'), 'avatar');
+        expect(file.name).toBe('avatar.png');
+    });
+
+    test('keeps the filename untouched when it already has an extension', () => {
+        const file = getFileFromBlob(blob('image/png'), 'avatar.gif');
+        expect(file.name).toBe('avatar.gif');
+    });
+
+    test('keeps dotfile names as-is', () => {
+        const file = getFileFromBlob(blob('text/plain'), '.env');
+        expect(file.name).toBe('.env');
+    });
+
+    test('honours an explicitly passed extension over the blob type', () => {
+        const file = getFileFromBlob(blob('image/png'), 'avatar', null, 'webp');
+        expect(file.name).toBe('avatar.webp');
+    });
+});

--- a/src/js/utils/getFileFromBlob.js
+++ b/src/js/utils/getFileFromBlob.js
@@ -23,8 +23,15 @@ export const getFileFromBlob = (
         filename = getDateString();
     }
 
-    // if filename supplied but no extension and filename has extension
-    if (filename && extension === null && getExtensionFromFilename(filename)) {
+    // if filename already carries an extension keep it as is, otherwise fall
+    // through and append a guessed one. `getExtensionFromFilename` returns the
+    // whole name for dotless names like "avatar", so also check for a dot.
+    if (
+        filename &&
+        extension === null &&
+        filename.includes('.') &&
+        getExtensionFromFilename(filename)
+    ) {
         file.name = filename;
     }
     else {


### PR DESCRIPTION
When a file is loaded from a URL whose last path segment has no extension (say `https://example.com/files/avatar` that returns `image/png`), the resulting file ends up named `avatar` rather than `avatar.png`.

The check in `getFileFromBlob` meant to ask "does the filename already have an extension?" by calling `getExtensionFromFilename(filename)`, but that helper is just `name.split('.').pop()`, which returns the whole string for a dotless name. So `avatar` looks like it already carries an extension and the type-guessed one never gets appended. I added a `filename.includes('.')` check so only names that actually contain a dot are treated as already-extensioned; dotfiles like `.env` and names that already have an extension are unaffected.

Added a test around `getFileFromBlob` covering the dotless case plus the existing keep-as-is paths.