### PR TITLE
Fix ja-ja labelFileProcessing (読込中 -> アップロード中)

### DIFF
--- a/locale/ja-ja.js
+++ b/locale/ja-ja.js
@@ -5,7 +5,7 @@ export default {
     labelFileSizeNotAvailable: "ファイルサイズがみつかりません",
     labelFileLoading: "読込中...",
     labelFileLoadError: "読込中にエラーが発生",
-    labelFileProcessing: "読込中...",
+    labelFileProcessing: "アップロード中...",
     labelFileProcessingComplete: "アップロード完了",                                                                                          
     labelFileProcessingAborted: "アップロードがキャンセルされました",                                                                           
     labelFileProcessingError: "アップロード中にエラーが発生",                                                                                 


### PR DESCRIPTION
`labelFileProcessing` in `locale/ja-ja.js` is set to `"読込中..."`, which is the same string as `labelFileLoading` two lines above it. That makes the loading state and the uploading state show identical text, so they can't be told apart.

The English source for this key is `Uploading` (while `labelFileLoading` is `Loading`), and the rest of the Japanese processing labels already use アップロード:

- `labelFileProcessingComplete`: アップロード完了
- `labelFileProcessingAborted`: アップロードがキャンセルされました
- `labelFileProcessingError`: アップロード中にエラーが発生

`labelFileProcessing` was the only key in that group still using 読込中. The ko-kr and zh-cn locales also keep the two states distinct (불러오는 중 / 업로드 중, 加载 / 上传).

Changed it to `"アップロード中..."` so it matches the source string and the surrounding labels.
